### PR TITLE
Don't make the DT in the session descriptions bold. Instead, make the…

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -28,11 +28,9 @@
         [role=rowheader] {padding-left: 0; font-size: 1em}
         .room {display: none}
       }
-      @supports (display: run-in) {
-	dt {display: run-in}
-	dt::after {content: " "}
-	dd {margin-left: 0}
-      }
+      dd {margin-left: 7em}
+      dd {min-height: 1.3em} /* Make sure there is at least one line */
+      dt {float: left; clear: left; margin-right: 0.33em; font-weight: inherit}
     </style>
   </head>
 
@@ -108,18 +106,19 @@
     </template>
     <template id="session">
       <h3 class="title"></h3>
-      <p>In room <span class="room-name"></span>, <span class="room-floor"></span></p>
       <dl>
         <dt>Proposer:</dt>
-        <dd><span class="organizer-name"></span> - <a class="organizer-email"></a></dd>
+        <dd><span class="organizer-name"></span> – <a class="organizer-email"></a></dd>
         <dt>Summary:</dt>
         <dd class="summary"></dd>
         <dt>Type of session:</dt>
         <dd class="type"></dd>
         <dt>Goals:</dt>
         <dd><ul class="goals"></ul></dd>
-        <dt>IRC Channel</dt>
+        <dt>IRC Channel:</dt>
         <dd class="irc"></dd>
+	<dt>Room:</dt>
+        <dd><span class="room-name"></span>, <span class="room-floor"></span></dd>
       </dl>
     </template>
 

--- a/lib/template.html
+++ b/lib/template.html
@@ -32,6 +32,7 @@
       dd {min-height: 1.3em} /* Make sure there is at least one line */
       dt {float: left; clear: left; margin-right: 0.33em; font-weight: inherit}
     </style>
+    <!-- pragma check.pl = noprevnext -->
   </head>
 
   <body>
@@ -63,8 +64,9 @@
 	  <a href="venue.html" accesskey="5">Venue</a>
 	  <a href="travel.html" accesskey="6">Accommodation and transportation</a>
 	  <a href="events.html" accesskey="7">Side events</a>
-	  <a href="sponsorship.html" accesskey="8">Sponsorship</a>
-	  <a href="../../../2002/09/TPOverview.html" accesskey="9" title="Technical Plenary (TPAC) Meetings">About TPAC</a>
+	  <a href="local.html" accesskey="8">Local</a>
+	  <a href="sponsorship.html" accesskey="9">Sponsorship</a>
+	  <a href="../../../2002/09/TPOverview.html" accesskey="t" title="Technical Plenary (TPAC) Meetings">About TPAC</a>
 	</p>
       </nav>
     </header>


### PR DESCRIPTION
… DL look more like a table with two columns. Make the room also part of that DL rather than a separate P element. Synchronize the <nav> in the <header> with the <nav> on other TPAC pages.