### PR TITLE
[calendar] Use project calendar status by default, add "quiet" mode

### DIFF
--- a/tools/update-calendar.mjs
+++ b/tools/update-calendar.mjs
@@ -1,11 +1,34 @@
 #!/usr/bin/env node
+/**
+ * This tool creates or updates the calendar entry of a session, or of all
+ * sessions. Unless the calendar entry status is specified, the tool uses the
+ * calendar entry status specified in the associated project's description
+ * (e.g., "calendar: tentative").
+ *
+ * To run the tool:
+ *
+ *  node tools/update-calendar.mjs [all or session number] [[status]] [[quiet]]
+ *
+ * where [all or session number] is either "all" to update all calendar entries
+ * or a session number, [[status]] is an optional calendar entry status
+ * ("draft", "tentative", or "confirmed") and [[quiet]] is the optional "quiet"
+ * string to tell the project to silently skip sessions that have validation
+ * errors instead of throwing an error.
+ *
+ * The "quiet" flag allows to run the tool automatically when a session is
+ * created or updated as part of a job, without having to worry about whether
+ * the session is valid. Without the "quiet" flag, the job would fail if the
+ * session itself needs fixing.
+ */
+
 import puppeteer from 'puppeteer';
 import { getEnvKey } from './lib/envkeys.mjs';
 import { fetchProject } from './lib/project.mjs';
 import { convertSessionToCalendarEntry } from './lib/calendar.mjs';
 import { validateSession } from './lib/validate.mjs';
 
-async function main(sessionNumber, status) {
+async function main(sessionNumber, status, options) {
+  options = options ?? {};
   console.log(`Retrieve environment variables...`);
   const PROJECT_OWNER = await getEnvKey('PROJECT_OWNER');
   console.log(`- PROJECT_OWNER: ${PROJECT_OWNER}`);
@@ -13,10 +36,6 @@ async function main(sessionNumber, status) {
   console.log(`- PROJECT_NUMBER: ${PROJECT_NUMBER}`);
   const CALENDAR_SERVER = await getEnvKey('CALENDAR_SERVER', 'www.w3.org');
   console.log(`- CALENDAR_SERVER: ${CALENDAR_SERVER}`);
-  const W3C_LOGIN = await getEnvKey('W3C_LOGIN');
-  console.log(`- W3C_LOGIN: ${W3C_LOGIN}`);
-  const W3C_PASSWORD = await getEnvKey('W3C_PASSWORD');
-  console.log(`- W3C_PASSWORD: ***`);
   const ROOM_ZOOM = await getEnvKey('ROOM_ZOOM', {}, true);
   const CHAIR_W3CID = await getEnvKey('CHAIR_W3CID', {}, true);
   console.log(`Retrieve environment variables... done`);
@@ -27,6 +46,24 @@ async function main(sessionNumber, status) {
   if (!project) {
     throw new Error(`Project ${PROJECT_OWNER}/${PROJECT_NUMBER} could not be retrieved`);
   }
+  if (!status) {
+    status = project.metadata?.calendar ?? 'no';
+    if (status) {
+      console.log(`- using default project's calendar entry status: "${status}"`);
+    }
+  }
+  if (!['draft', 'tentative', 'confirmed'].includes(status)) {
+    console.log(`- current calendar status is "${status}", no entry to create as a result`);
+    return;
+  }
+
+  console.log(`Retrieve credentials for the calendar...`);
+  const W3C_LOGIN = await getEnvKey('W3C_LOGIN');
+  console.log(`- W3C_LOGIN: ${W3C_LOGIN}`);
+  const W3C_PASSWORD = await getEnvKey('W3C_PASSWORD');
+  console.log(`- W3C_PASSWORD: ***`);
+  console.log(`Retrieve credentials for the calendar... done`)
+
   project.chairsToW3CID = CHAIR_W3CID;
   let sessions = sessionNumber ?
     project.sessions.filter(s => s.number === sessionNumber) :
@@ -54,7 +91,12 @@ async function main(sessionNumber, status) {
   sessions = sessions.filter(s => !!s);
   if (sessionNumber) {
     if (sessions.length === 0) {
-      throw new Error(`Session ${sessionNumber} contains errors that need fixing`);
+      if (options.quiet) {
+        console.log(`Session ${sessionNumber} contains errors that need fixing, skip`);
+      }
+      else {
+        throw new Error(`Session ${sessionNumber} contains errors that need fixing`);
+      }
     }
   }
   else {
@@ -96,13 +138,17 @@ if (!allSessions || !allSessions.match(/^\d+$|^all$/)) {
 }
 const sessionNumber = allSessions === 'all' ? undefined : parseInt(allSessions, 10);
 
-const status = process.argv[3] ?? 'draft';
-if (!['draft', 'tentative', 'confirmed'].includes(status)) {
+const options = {
+  quiet: (process.argv[3] === 'quiet') || (process.argv[4] === 'quiet')
+};
+const status = process.argv[3] === 'quiet' ? undefined : process.argv[3];
+
+if (status && !['draft', 'tentative', 'confirmed'].includes(status)) {
   console.log('Command needs to receive a valid entry status "draft", "tentative" or "confirmed" as second parameter');
   process.exit(1);
 }
 
-main(sessionNumber, status)
+main(sessionNumber, status, options)
   .catch(err => {
     console.log(`Something went wrong: ${err.message}`);
     throw err;


### PR DESCRIPTION
The calendar update tool needed to be run manually, partly because we didn't feel like automating it, and partly because there was no way to specify the calendar entry status to use (draft, tentative or confirmed).

The script now looks for a `calendar` property in the project's metadata (to be set in the project's description) and uses that status to determine whether it should:
- do nothing (no property or property set to `no`), which is typically useful during the first phase, when sessions get collected.
- create a `draft` calendar entry, which should only be useful on a temporary basis to make sure that things work as intended.
- create a `tentative` calendar entry, for use once a first grid has been announced.
- create a `confirmed` calendar entry, for use once the final grid has been announced.

The script now also features a `quiet`, which makes it exit quietly without throwing an error even if the session contains errors that need fixing.

Changes make it possible to automate calendar updates, as envisioned in #68.