### PR TITLE
Handle plenary sessions

### DIFF
--- a/tools/lib/project.mjs
+++ b/tools/lib/project.mjs
@@ -318,7 +318,7 @@ function parseProjectDescription(desc) {
   if (desc) {
     desc.split(/,/)
       .map(param => param.trim())
-      .map(param => param.split(/:/).map(val => val.trim()))
+      .map(param => param.split(/:/).map(val => val.trim().toLowerCase()))
       .map(param => metadata[param[0]] = param[1]);
   }
   return metadata;

--- a/tools/lib/session.mjs
+++ b/tools/lib/session.mjs
@@ -164,6 +164,11 @@ export async function initSectionHandlers() {
         handler.serialize = value => value === 30 ? '30 minutes' : '60 minutes (Default)';
         break;
 
+      case 'type':
+        handler.parse = value => value.toLowerCase() === 'plenary' ? 'plenary' : 'breakout';
+        handler.serialize = value => value === 'plenary' ? 'Plenary' : 'Breakout (Default)';
+        break;
+
       case 'conflicts':
         // List of GitHub issues
         handler.parse = value => parseList(value, { spaceSeparator: true, prefix: '#' })

--- a/tools/lib/validate.mjs
+++ b/tools/lib/validate.mjs
@@ -283,6 +283,25 @@ ${projectErrors.map(error => '- ' + error).join('\n')}`);
     }
   }
 
+  // Check that there is no plenary session scheduled at the same time as this
+  // session
+  if (sessions.slot) {
+    const plenaryWarnings = project.sessions
+      .filter(s => s !== session && s.slot && s.description.type === 'plenary')
+      .filter(s => s.slot === session.slot)
+      .map(other => {
+        return `Same slot "${session.slot}" as plenary session "${other.title}" (#${other.number})`;
+      });
+    if (plenaryWarnings.length > 0) {
+      errors.push({
+        session: sessionNumber,
+        severity: 'warning',
+        type: 'plenary',
+        messages: plenaryWarnings
+      });
+    }
+  }
+
   // No two sessions can use the same IRC channel during the same slot
   if (session.description.shortname) {
     const ircConflicts = project.sessions


### PR DESCRIPTION
See https://github.com/w3c/tpac-breakouts/issues/74.

Validation will no longer report errors for plenary sessions scheduled at the same time and in the same room, since that is to be expected. Validation will now report a number of scheduling errors linked to the plenary status of a session: too many sessions in a plenary, non empty list of conflicting sessions, etc. A warning is also returned when a session is scheduled in parallel with a plenary session (that may be needed but that's not normal).

The scheduling algorithm was adjusted to schedule sessions in plenary first and schedule multiple sessions in the same plenary slot.

The code has not been tested so probably buggy, but that should be easy to fix once we need it.

Calendar management is still missing. Keeping the PR as draft in the meantime.