### PR TITLE
Force the IRC channel of plenary session to #plenary

### DIFF
--- a/tools/setup-irc.mjs
+++ b/tools/setup-irc.mjs
@@ -88,6 +88,9 @@ async function main({ number, onlyCommands, dismissBots } = {}) {
     console.log(`- found ${sessions.length} sessions assigned to slots: ${sessions.map(s => s.number).join(', ')}`);
   }
   sessions = await Promise.all(sessions.map(async session => {
+    if (session.description.type === 'plenary') {
+      return null;
+    }
     const sessionErrors = (await validateSession(session.number, project))
       .filter(error => error.severity === 'error');
     if (sessionErrors.length > 0) {


### PR DESCRIPTION
See "Force IRC channel of plenary sessions to #plenary" in #74.

The name of the plenary IRC channel can be modified by setting a `plenary channel` setting in the project's description.