### PR TITLE
Add support for breakout events that span multiple days

### DIFF
--- a/tools/add-minutes.mjs
+++ b/tools/add-minutes.mjs
@@ -28,7 +28,7 @@ async function main(number) {
     throw new Error(`Project ${PROJECT_OWNER}/${PROJECT_NUMBER} could not be retrieved`);
   }
   project.chairsToW3CID = CHAIR_W3CID;
-  let sessions = project.sessions.filter(s => s.slot && s.room &&
+  let sessions = project.sessions.filter(s => s.day && s.slot && s.room &&
     (!number || s.number === number));
   sessions.sort((s1, s2) => s1.number - s2.number);
   if (number) {
@@ -72,17 +72,16 @@ async function main(number) {
   }
   console.log(`Retrieve project ${PROJECT_OWNER}/${PROJECT_NUMBER} and session(s)... done`);
 
-  // TODO: date is in the timezone of the TPAC even but actual dated URL
-  // is on Boston time. No big deal for TPAC meetings in US / Europe, but
-  // problematic when TPAC is in Asia.
-  const date = project.metadata.date;
-  const year = date.substring(0, 4);
-  const month = date.substring(5, 7);
-  const day = date.substring(8, 10);
-
   console.log();
   console.log('Link to minutes...');
   for (const session of sessions) {
+    // TODO: date is in the timezone of the TPAC event but actual dated URL
+    // is on Boston time. No big deal for TPAC meetings in US / Europe, but
+    // problematic when TPAC is in Asia.
+    const day = project.days.find(day => day.name === session.day);
+    const year = day.date.substring(0, 4);
+    const month = day.date.substring(5, 7);
+    const day = day.date.substring(8, 10);
     const url = `https://www.w3.org/${year}/${month}/${day}-${session.description.shortname.substring(1)}-minutes.html`;
     const response = await fetch(url);
     if ((response.status !== 200) && (response.status !== 401)) {

--- a/tools/create-recording-pages.mjs
+++ b/tools/create-recording-pages.mjs
@@ -105,8 +105,6 @@ async function main() {
   }
   project.chairsToW3CID = CHAIR_W3CID;
   console.log(`- ${project.sessions.length} sessions`);
-  console.log(`- ${project.rooms.length} rooms`);
-  console.log(`- ${project.slots.length} slots`);
   console.log(`Retrieve project ${PROJECT_OWNER}/${PROJECT_NUMBER}... done`);
 
   console.log();

--- a/tools/minutes-to-w3c.mjs
+++ b/tools/minutes-to-w3c.mjs
@@ -24,7 +24,7 @@ async function main(number) {
   if (!project) {
     throw new Error(`Project ${PROJECT_OWNER}/${PROJECT_NUMBER} could not be retrieved`);
   }
-  let sessions = project.sessions.filter(s => s.slot && s.room &&
+  let sessions = project.sessions.filter(s => s.day && s.slot && s.room &&
     (!number || s.number === number));
   sessions.sort((s1, s2) => s1.number - s2.number);
   if (number) {

--- a/tools/setup-irc.mjs
+++ b/tools/setup-irc.mjs
@@ -73,14 +73,14 @@ async function main({ number, onlyCommands, dismissBots } = {}) {
     throw new Error(`Project ${PROJECT_OWNER}/${PROJECT_NUMBER} could not be retrieved`);
   }
   project.chairsToW3CID = CHAIR_W3CID;
-  let sessions = project.sessions.filter(s => s.slot &&
+  let sessions = project.sessions.filter(s => s.day && s.slot &&
     (!number || s.number === number));
   sessions.sort((s1, s2) => s1.number - s2.number);
   if (number) {
     if (sessions.length === 0) {
       throw new Error(`Session ${number} not found in project ${PROJECT_OWNER}/${PROJECT_NUMBER}`);
     }
-    else if (!sessions[0].slot) {
+    else if (!sessions[0].day || !sessions[0].slot) {
       throw new Error(`Session ${number} not assigned to a slot in project ${PROJECT_OWNER}/${PROJECT_NUMBER}`);
     }
   }
@@ -118,9 +118,16 @@ async function main({ number, onlyCommands, dismissBots } = {}) {
     }
     channels[channel].push(session);
     channels[channel].sort((s1, s2) => {
-      const slot1 = project.slots.findIndex(slot => slot.name === s1.slot);
-      const slot2 = project.slots.findIndex(slot => slot.name === s2.slot);
-      return slot1 - slot2;
+      const day1 = project.days.findIndex(day => day.name === s1.day);
+      const day2 = project.days.findIndex(day => day.name === s2.day);
+      if (day1 !== day2) {
+        return day1 - day2;
+      }
+      else {
+        const slot1 = project.slots.findIndex(slot => slot.name === s1.slot);
+        const slot2 = project.slots.findIndex(slot => slot.name === s2.slot);
+        return slot1 - slot2;
+      }
     });
   }
   sessions = Object.values(channels).map(sessions => sessions[0]);

--- a/tools/update-calendar.mjs
+++ b/tools/update-calendar.mjs
@@ -67,13 +67,13 @@ async function main(sessionNumber, status, options) {
   project.chairsToW3CID = CHAIR_W3CID;
   let sessions = sessionNumber ?
     project.sessions.filter(s => s.number === sessionNumber) :
-    project.sessions.filter(s => s.slot);
+    project.sessions.filter(s => s.day && s.slot);
   sessions.sort((s1, s2) => s1.number - s2.number);
   if (sessionNumber) {
     if (sessions.length === 0) {
       throw new Error(`Session ${sessionNumber} not found in project ${PROJECT_OWNER}/${PROJECT_NUMBER}`);
     }
-    else if (!sessions[0].slot) {
+    else if (!sessions[0].day || !sessions[0].slot) {
       throw new Error(`Session ${sessionNumber} not assigned to a slot in project ${PROJECT_OWNER}/${PROJECT_NUMBER}`);
     }
   }

--- a/tools/upload-grid.mjs
+++ b/tools/upload-grid.mjs
@@ -30,23 +30,28 @@ async function main({ filename, apply }) {
   console.warn(`Extract grid from HTML page...`);
   const rooms = project.rooms;
   const slots = project.slots;
+  const days = project.days;
   const configs = readconfig(filename);
   console.warn(`Extract grid from HTML page... done`);
 
   console.warn(`Assign sessions to rooms and slots...`);
   const updated = [];
   for (const config of configs) {
-    if (!sessions.map(s => s.number === config.number)) {
+    if (!sessions.find(s => s.number === config.number)) {
       throw new Error('Unknown session ' + config.number);
     }
-    if (!slots.map(s => s.name === config.slot)) {
+    if (!days.find(s => s.name === config.day)) {
+      throw new Error('Unknown day ' + config.slot + ' in ' + config.number);
+    }
+    if (!slots.find(s => s.name === config.slot)) {
       throw new Error('Unknown slot ' + config.slot + ' in ' + config.number);
     }
-    if (!rooms.map(s => s.name === config.room)) {
+    if (!rooms.find(s => s.name === config.room)) {
       throw new Error('Unknown room ' + config.room + ' in ' + config.number);
     }
     let session = sessions.find(s => s.number === config.number);
-    if (session.room !== config.room || session.slot !== config.slot) {
+    if (session.room !== config.room || session.day !== config.day || session.slot !== config.slot) {
+      session.day = config.day;
       session.room = config.room;
       session.slot = config.slot;
       updated.push(session);

--- a/tools/validate-grid.mjs
+++ b/tools/validate-grid.mjs
@@ -40,8 +40,6 @@ async function main(validation) {
   }
   project.chairsToW3CID = CHAIR_W3CID;
   console.log(`- ${project.sessions.length} sessions`);
-  console.log(`- ${project.rooms.length} rooms`);
-  console.log(`- ${project.slots.length} slots`);
   console.log(`Retrieve project ${PROJECT_OWNER}/${PROJECT_NUMBER}... done`);
 
   console.log();

--- a/tools/validate-session.mjs
+++ b/tools/validate-session.mjs
@@ -72,8 +72,6 @@ async function main(sessionNumber, changesFile) {
     throw new Error(`Session ${sessionNumber} not found in project ${PROJECT_OWNER}/${PROJECT_NUMBER}`);
   }
   console.log(`- ${project.sessions.length} sessions`);
-  console.log(`- ${project.rooms.length} rooms`);
-  console.log(`- ${project.slots.length} slots`);
   project.chairsToW3CID = CHAIR_W3CID;
   console.log(`Retrieve project ${PROJECT_OWNER}/${PROJECT_NUMBER}... done`);
 


### PR DESCRIPTION
This update makes it possible to organize a breakouts event that spans multiple days. Sessions now need a room, a day and a slot within that day. For that to work, the project must have an additional "Day" single select custom field that lists possible days, using the format `YYYY-MM-DD` or `[name] (YYYY-MM-DD)`. For a single day event, this field will have only one option.

The grid suggestion script was adjusted accordingly to consider all possible days and slots, instead of just slots. Validation logic was also updated.

The code expects all days to be "equal", and in particular to have the exact same slots. Additional constraints such as unavailable slots on a particular day are not yet supported (a similar constraint that may be worth supporting is "this room is not available on day 2 afternoon").

Important: sessions can still only be associated with one and only one room, day and slot. There is no way to associate sessions with more than one slots for now!