### PR TITLE
Support new "Discussion" section

### DIFF
--- a/test/check-serialization.mjs
+++ b/test/check-serialization.mjs
@@ -12,15 +12,6 @@ async function fetchTestProject() {
     await getEnvKey('PROJECT_NUMBER'));
 }
 
-function stripDetails(errors) {
-  return errors.map(err => {
-    if (err.details) {
-      delete err.details;
-    }
-    return err;
-  });
-}
-
 describe('The serialization of session descriptions', function () {
   beforeEach(function () {
     initTestEnv();
@@ -166,6 +157,56 @@ _No response_
 _No response_`;
     const desc = parseSessionBody(initialBody);
     const serializedBody = serializeSessionDescription(desc);
+    assert.strictEqual(serializedBody, initialBody);
+  });
+
+
+  it('parses the discussion URL correctly', async function () {
+    setEnvKey('PROJECT_NUMBER', 'tpac2023');
+    setEnvKey('ISSUE_TEMPLATE', 'test/data/tpac-template.yml');
+    const project = await fetchTestProject();
+    await initSectionHandlers(project);
+    const initialBody = `### Estimate of in-person participants
+
+16-30
+
+### Select preferred dates and times (11-15 September)
+
+- [ ] Monday, 09:30 - 11:00
+- [ ] Monday, 11:30 - 13:00
+- [ ] Monday, 14:30 - 16:30
+- [ ] Monday, 17:00 - 18:30
+- [ ] Tuesday, 09:30 - 11:00
+- [ ] Tuesday, 11:30 - 13:00
+- [ ] Tuesday, 14:30 - 16:30
+- [ ] Tuesday, 17:00 - 18:30
+- [ ] Thursday, 09:30 - 11:00
+- [ ] Thursday, 11:30 - 13:00
+- [ ] Thursday, 14:30 - 16:30
+- [ ] Thursday, 17:00 - 18:30
+- [ ] Friday, 09:30 - 11:00
+- [ ] Friday, 11:30 - 13:00
+- [ ] Friday, 14:30 - 16:30
+- [ ] Friday, 17:00 - 18:30
+
+### Other sessions where we should avoid scheduling conflicts (Optional)
+
+_No response_
+
+### Other instructions for meeting planners (Optional)
+
+_No response_
+
+### Discussion channel (Optional)
+
+https://example.org/discuss
+
+### Agenda for the meeting.
+
+_No response_`;
+    const desc = parseSessionBody(initialBody);
+    const serializedBody = serializeSessionDescription(desc);
+    assert.strictEqual(desc.discussion, 'https://example.org/discuss');
     assert.strictEqual(serializedBody, initialBody);
   });
 });

--- a/tools/lib/calendar.mjs
+++ b/tools/lib/calendar.mjs
@@ -432,8 +432,13 @@ async function fillCalendarEntry({ page, entry, session, project, status, zoom }
   else {
     await fillTextInput('input#event_title', session.title);
     await fillTextInput('textarea#event_description', convertToCalendarMarkdown(session.description.description));
-    await fillTextInput('input#event_chat',
-      `https://irc.w3.org/?channels=${encodeURIComponent(session.description.shortname)}`);
+    if (session.description.discussion) {
+      await fillTextInput('input#event_chat', session.description.discussion);
+    }
+    else {
+      await fillTextInput('input#event_chat',
+        `https://irc.w3.org/?channels=${encodeURIComponent(session.description.shortname)}`);
+    }
     await fillTextInput('input#event_agendaUrl', getAgendaUrl(session));
     await fillTextInput('textarea#event_agenda', formatAgenda(session));
   }

--- a/tools/lib/session.mjs
+++ b/tools/lib/session.mjs
@@ -171,6 +171,33 @@ export async function initSectionHandlers(project) {
         handler.validate = value => value.match(/^(\`#?[A-Za-z0-9\-_]+\`|#?[A-Za-z0-9\-_]+)$/);
         break;
 
+      case 'discussion':
+        handler.parse = value => {
+          const match = value.match(/^\[(.+)\]\((.*)\)$/i);
+          if (match) {
+            return match[2];
+          }
+          else {
+            return value;
+          }
+        };
+        handler.validate = value => {
+          const match = value.match(/^\[(.+)\]\((.*)\)$/i);
+          try {
+            if (match) {
+              new URL(match[2]);
+            }
+            else {
+              new URL(value);
+            }
+            return true;
+          }
+          catch (err) {
+            return false;
+          }
+        };
+        break;
+
       case 'attendance':
         handler.parse = value => value.toLowerCase() === 'restricted to tpac registrants' ?
           'restricted' : 'public';


### PR DESCRIPTION
The section must contain a URL. It may contain a URL rendered as a link such as `[foo](https://example.org/)`, but note serialization will get back to a raw URL for now.

If specified, the discussion URL replaces the IRC link in the calendar entry.

Close #101.