### PR TITLE
Add mechanism to specify custom slot start/end times

### DIFF
--- a/test/check-meeting-parsing.mjs
+++ b/test/check-meeting-parsing.mjs
@@ -1,0 +1,185 @@
+import * as assert from 'node:assert';
+import { initTestEnv } from './init-test-env.mjs';
+import { getEnvKey, setEnvKey } from '../tools/lib/envkeys.mjs';
+import { fetchProject } from '../tools/lib/project.mjs';
+import { groupSessionMeetings,
+         computeSessionCalendarUpdates,
+         parseSessionMeetings,
+         serializeSessionMeetings,
+         applyMeetingsChanges } from '../tools/lib/meetings.mjs';
+
+async function fetchTestProject() {
+  return fetchProject(
+    await getEnvKey('PROJECT_OWNER'),
+    await getEnvKey('PROJECT_NUMBER'));
+}
+
+describe('The meeting field parser', function () {
+  before(function () {
+    initTestEnv();
+    setEnvKey('PROJECT_NUMBER', 'group-meetings');
+    setEnvKey('ISSUE_TEMPLATE', 'test/data/template-group.yml');
+  });
+
+  it('parses a regular list of meetings', async function () {
+    const project = await fetchTestProject();
+    const session = {
+      meeting: 'Tuesday, Room 1, 9:00; Room 1, 2020-02-11, 11:00 - 13:00'
+    };
+    const meetings = parseSessionMeetings(session, project);
+    assert.deepStrictEqual(meetings, [
+      {
+        day: 'Tuesday (2042-02-11)',
+        room: 'Room 1',
+        slot: '9:00 - 11:00'
+      },
+      {
+        day: '2020-02-11',
+        room: 'Room 1',
+        slot: '11:00 - 13:00'
+      }
+    ]);
+  });
+
+  it('serializes a regular list of meetings', async function () {
+    const project = await fetchTestProject();
+    const meetings = [
+      {
+        day: 'Tuesday (2042-02-11)',
+        room: 'Room 1',
+        slot: '9:00 - 11:00'
+      },
+      {
+        day: '2020-02-11',
+        room: 'Room 2',
+        slot: '11:00 - 13:00'
+      }
+    ];
+    assert.deepStrictEqual(serializeSessionMeetings(meetings, project), {
+      meeting: 'Tuesday, 9:00, Room 1; 2020-02-11, 11:00, Room 2'
+    });
+  });
+
+  it('parses a list of meetings with custom start/end times', async function () {
+    const project = await fetchTestProject();
+    const session = { meeting: '9:00<8:30> - 11:00<10:30>' };
+    const meetings = parseSessionMeetings(session, project);
+    assert.deepStrictEqual(meetings, [
+      {
+        slot: '9:00 - 11:00',
+        actualStart: '8:30',
+        actualEnd: '10:30'
+      }
+    ]);
+  });
+
+  it('serializes a list of meetings with custom start/end times', async function () {
+    const project = await fetchTestProject();
+    const meetings = [
+      {
+        slot: '9:00 - 11:00',
+        actualStart: '8:30'
+      },
+      {
+        slot: '11:00 - 13:00',
+        actualEnd: '12:30'
+      }
+    ];
+    assert.deepStrictEqual(serializeSessionMeetings(meetings, project), {
+      meeting: '9:00<8:30>; 11:00 - 13:00<12:30>'
+    });
+  });
+
+  it('validates a meeting with custom start/end times within the slot', async function () {
+    const project = await fetchTestProject();
+    const session = { meeting: '11:00<11:15> - 13:00<12:30>' };
+    const meetings = parseSessionMeetings(session, project);
+    assert.deepStrictEqual(serializeSessionMeetings(meetings, project), session);
+  });
+
+  it('validates an early morning meeting', async function () {
+    const project = await fetchTestProject();
+    const session = { meeting: '9:00<07:00>' };
+    const meetings = parseSessionMeetings(session, project);
+    assert.deepStrictEqual(serializeSessionMeetings(meetings, project), session);
+  });
+
+  it('validates a late evening meeting', async function () {
+    const project = await fetchTestProject();
+    const session = { meeting: '16:00 - 18:00<19:00>' };
+    const meetings = parseSessionMeetings(session, project);
+    assert.deepStrictEqual(serializeSessionMeetings(meetings, project), session);
+  });
+
+  it('rejects a meeting with a custom start time that overlaps with former slot', async function () {
+    const project = await fetchTestProject();
+    const session = { meeting: '11:00<10:30>' };
+    const meetings = parseSessionMeetings(session, project);
+    assert.deepStrictEqual(meetings, [
+      { invalid: '11:00<10:30>' }
+    ]);
+  });
+
+  it('rejects a meeting with a custom end time that overlaps with next slot', async function () {
+    const project = await fetchTestProject();
+    const session = { meeting: '11:00 - 13:00<16:30>' };
+    const meetings = parseSessionMeetings(session, project);
+    assert.deepStrictEqual(meetings, [
+      { invalid: '11:00 - 13:00<16:30>' }
+    ]);
+  });
+
+  it('rejects a meeting with a custom start time that makes no sense', async function () {
+    const project = await fetchTestProject();
+    const session = { meeting: '11:00<14:30>' };
+    const meetings = parseSessionMeetings(session, project);
+    assert.deepStrictEqual(meetings, [
+      { invalid: '11:00<14:30>' }
+    ]);
+  });
+
+  it('rejects a meeting with a custom end time that makes no sense', async function () {
+    const project = await fetchTestProject();
+    const session = { meeting: '9:00 - 11:00<8:30>' };
+    const meetings = parseSessionMeetings(session, project);
+    assert.deepStrictEqual(meetings, [
+      { invalid: '9:00 - 11:00<8:30>' }
+    ]);
+  });
+
+  it('rejects a meeting with custom start/end times that make no sense', async function () {
+    const project = await fetchTestProject();
+    const session = { meeting: '9:00<10:30> - 11:00<9:30>' };
+    const meetings = parseSessionMeetings(session, project);
+    assert.deepStrictEqual(meetings, [
+      { invalid: '9:00<10:30> - 11:00<9:30>' }
+    ]);
+  });
+
+  it('rejects a meeting with custom start/end times that do not change anything', async function () {
+    const project = await fetchTestProject();
+    const session = { meeting: '9:00<9:00> - 11:00<11:00>' };
+    const meetings = parseSessionMeetings(session, project);
+    assert.deepStrictEqual(meetings, [
+      { invalid: '9:00<9:00> - 11:00<11:00>' }
+    ]);
+  });
+
+  it('uses custom start/end times when it merges contiguous slots', async function () {
+    const project = await fetchTestProject();
+    const session = {
+      room: 'Room 1',
+      day: 'Monday (2042-02-10)',
+      meeting: '9:00<8:30>; 11:00; 14:00 - 16:00<15:30>'
+    };
+    const merged = groupSessionMeetings(session, project);
+    assert.deepStrictEqual(merged, [
+      {
+        room: 'Room 1',
+        day: 'Monday (2042-02-10)',
+        start: '8:30',
+        end: '15:30'
+      }
+    ]);
+  });
+});

--- a/tools/lib/meetings.mjs
+++ b/tools/lib/meetings.mjs
@@ -1,6 +1,63 @@
 import * as YAML from 'yaml';
 
 /**
+ * Normalize times for comparison purpose, making sure that hours always have
+ * two digits: from 9:00 to 09:00
+ */
+function padTime(time) {
+  if (!time) {
+    return null;
+  }
+  return (time.length === 4) ? '0' + time : time;
+}
+
+/**
+ * Validate the actual start/end times of a meeting slot
+ */
+function validateActualTimes(meeting, project) {
+  const slots = project.slots;
+  const actualStart = padTime(meeting.actualStart);
+  const actualEnd = padTime(meeting.actualEnd);
+  const slotIndex = slots.findIndex(s => s.name === meeting.slot);
+  const slot = slots[slotIndex];
+  const previous = slotIndex > 0 ? slots[slotIndex - 1] : null;
+  const next = slotIndex < slots.length - 1 ? slots[slotIndex + 1] : null;
+  if (actualStart) {
+    if (actualStart === padTime(slot.start)) {
+      // Actual start time is useless since it matches the slot's start time
+      return false;
+    }
+    else if (actualStart >= padTime(slot.end)) {
+      // Actual start time makes no sense
+      return false;
+    }
+    else if (previous && actualStart < padTime(previous.end)) {
+      // Actual start time overlaps with previous slot
+      return false;
+    }
+  }
+  if (actualEnd) {
+    if (actualEnd === padTime(slot.end)) {
+      // Actual end time is useless since it matches the slot's end time
+      return false;
+    }
+    else if (actualEnd <= padTime(slot.start)) {
+      // Actual end time makes no sense
+      return false;
+    }
+    else if (next && actualEnd > padTime(next.start)) {
+      // Actual end time overlaps with next slot
+      return false;
+    }
+  }
+  if (actualStart && actualEnd && actualStart > actualEnd) {
+    // Actual start/end times do not make sense
+    return false;
+  }
+  return true;
+}
+
+/**
  * Retrieve the list of meetings that the session is associated with.
  *
  * For breakouts, this should return at most one meeting, from the `day`,
@@ -21,37 +78,87 @@ export function parseSessionMeetings(session, project) {
         str.split(',')
           .map(token => token.trim().toLowerCase())
           .forEach(token => {
-            let found = false;
-            for (const field of ['day', 'slot', 'room']) {
-              const option = project[field + 's'].find(option =>
-                option.name?.toLowerCase() === token ||
-                option.label?.toLowerCase() === token ||
-                option.date === token ||
-                option.start === token);
+            if (meeting.invalid) {
+              return;
+            }
+            // For rooms and days, the token is either going to be the option's
+            // full name, or its label, e.g., "Monday" or "Monday (2020-02-10)"
+            // For slots, this can be the full name, the start time, or either
+            // of them completed with an actual start and/or end time. For
+            // example: "9:00", "9:00<8:30>", "9:00-11:00", "9:00-11:00<10:30>"
+            // or "9:00<8:30> - 11:00<10:30>". The syntax is captured by the
+            // following regular expression, which returns the slot's
+            // start (1), actual start (2), end (3) and actual end (4) times.
+            const slotMatch = token.match(
+              /^(\d+:\d+)(?:<(\d+:\d+)>)?(?:\s*-\s*(\d+:\d+)(?:<(\d+:\d+)>)?)?$/);
+            if (slotMatch) {
+              let option = project.slots.find(option => padTime(option.start) === padTime(slotMatch[1]));
+              if (option && slotMatch[3] && option.end !== slotMatch[3]) {
+                option = null;
+              }
               if (option) {
-                meeting[field] = option.name;
-                found = true;
-                break;
+                meeting.slot = option.name;
+                if (slotMatch[2]) {
+                  meeting.actualStart = slotMatch[2];
+                }
+                if (slotMatch[4]) {
+                  meeting.actualEnd = slotMatch[4];
+                }
+                if (!validateActualTimes(meeting, project)) {
+                  meeting.invalid = str;
+                  if (meeting.actualStart) {
+                    delete meeting.actualStart;
+                  }
+                  if (meeting.actualEnd) {
+                    delete meeting.actualEnd;
+                  }
+                }
+                return;
               }
             }
-            if (!found) {
-              meeting.invalid = str;
-              meeting.room = null;
-              meeting.day = null;
-              meeting.slot = null;
+            else {
+              for (const field of ['day', 'room']) {
+                const option = project[field + 's'].find(option =>
+                  option.name?.toLowerCase() === token ||
+                  option.label?.toLowerCase() === token ||
+                  option.date === token);
+                if (option) {
+                  meeting[field] = option.name;
+                  return;
+                }
+              }
             }
+
+            // Still there? Token could not be mapped to an option
+            meeting.invalid = str;
+            return;
           });
+        if (meeting.invalid || !meeting.room) {
+          delete meeting.room;
+        }
+        if (meeting.invalid || !meeting.day) {
+          delete meeting.day;
+        }
+        if (meeting.invalid || !meeting.slot) {
+          delete meeting.slot;
+        }
         return meeting;
       });
   }
   
   if (session.room || session.day || session.slot) {
     // One meeting at least partially scheduled
-    return [{
-      room: session.room,
-      day: session.day,
-      slot: session.slot
-    }];
+    const meeting = {};
+    if (session.room) {
+      meeting.room = session.room;
+    }
+    if (session.day) {
+      meeting.day = session.day;
+    }
+    if (session.slot) {
+      meeting.slot = session.slot;
+    }
+    return [meeting];
   }
 
   return [];
@@ -78,27 +185,42 @@ export function serializeSessionMeetings(meetings, project) {
   const room = meetings.reduce((room, meeting) => {
     return (meeting.room && meeting.room === room) ? room : null;
   }, meetings[0].room);
-  return {
-    room,
-    meeting: meetings
-      .map(meeting => {
-        const tokens = [];
-        if (meeting.day) {
-          const day = project.days.find(day => day.name === meeting.day);
-          tokens.push(day.label ?? day.name);
+  const res = {};
+  if (room) {
+    res.room = room;
+  }
+  res.meeting = meetings
+    .map(meeting => {
+      const tokens = [];
+      if (meeting.day) {
+        const day = project.days.find(day => day.name === meeting.day);
+        tokens.push(day.label ?? day.name);
+      }
+      if (meeting.slot) {
+        const slot = project.slots.find(slot => slot.name === meeting.slot);
+        if (meeting.actualEnd) {
+          if (meeting.actualStart) {
+            tokens.push(`${slot.start}<${meeting.actualStart}> - ${slot.end}<${meeting.actualEnd}>`);
+          }
+          else {
+            tokens.push(`${slot.start} - ${slot.end}<${meeting.actualEnd}>`);
+          }
         }
-        if (meeting.slot) {
-          const slot = project.slots.find(slot => slot.name === meeting.slot);
+        else if (meeting.actualStart) {
+          tokens.push(`${slot.start}<${meeting.actualStart}>`);
+        }
+        else {
           tokens.push(slot.start);
         }
-        if (meeting.room && !room) {
-          const roomObj = project.rooms.find(room => room.name === meeting.room);
-          tokens.push(roomObj.label ?? roomObj.name);
-        }
-        return tokens.join(', ');
-      })
-      .join('; ')
-  };
+      }
+      if (meeting.room && !room) {
+        const roomObj = project.rooms.find(room => room.name === meeting.room);
+        tokens.push(roomObj.label ?? roomObj.name);
+      }
+      return tokens.join(', ');
+    })
+    .join('; ');
+  return res;
 }
 
 
@@ -139,8 +261,8 @@ export function groupSessionMeetings(session, project) {
       const slotIndex = project.slots.findIndex(s => s.name === meeting.slot);
       if (merged.length === 0) {
         merged.push({
-          start: slot.start,
-          end: slot.end,
+          start: meeting.actualStart ?? slot.start,
+          end: meeting.actualEnd ?? slot.end,
           startIndex: slotIndex,
           endIndex: slotIndex,
           meetings: [meeting]
@@ -149,14 +271,14 @@ export function groupSessionMeetings(session, project) {
       else {
         const last = merged[merged.length - 1];
         if (slotIndex === last.endIndex + 1) {
-          last.end = slot.end;
+          last.end = meeting.actualEnd ?? slot.end;
           last.endIndex = slotIndex;
           last.meetings.push(meeting);
         }
         else {
           merged.push({
-            start: slot.start,
-            end: slot.end,
+            start: meeting.actualStart ?? slot.start,
+            end: meeting.actualEnd ?? slot.end,
             startIndex: slotIndex,
             endIndex: slotIndex,
             meetings: [meeting]


### PR DESCRIPTION
See #100. If the start/end times of a meeting needs to be adjusted for some reason, the actual start/end times may now be specified in the `Meeting` field using `<HH:mm>` next to the time that needs to be modified.

For example:
- `9:00<8:30>`
- `9:00-11:00<10:30>`
- `11:00<11:15> - 13:00<12:45>`

Validation will reject problematic custom times:
- a custom start time that overlaps with a previous slot
- a custom end time that overlaps with a next slot
- custom times that do not change anything
- custom times that make no sense (e.g., because custom start time is later than the custom end time)

The custom start/end times are used in the calendar.

If a group meets during contiguous slots and custom start/end times are set for the inner slots, the custom start/end times are ignored. For example, the custom times are ignored in `9:00; 11:00<11:15> - 13:00<12:45>; 14:00` because this will map to only one calendar entry from `9:00` to `16:00`.