### PR TITLE
Add "Try me out" field mechanism to try schedule updates

### DIFF
--- a/test/stubs.mjs
+++ b/test/stubs.mjs
@@ -80,6 +80,12 @@ async function getTestData(testDataId) {
         field: { name: 'Meeting' }
       });
     }
+    if (session.trymeout) {
+      fields.push({
+        text: session.trymeout,
+        field: { name: 'Try me out' }
+      });
+    }
 
     return {
       id: `id_${uid++}`,
@@ -125,6 +131,9 @@ async function getTestData(testDataId) {
   if (custom.allowMultipleMeetings) {
     testData.allowMultipleMeetings = custom.allowMultipleMeetings;
   }
+  if (custom.allowTryMeOut) {
+    testData.allowTryMeOut = custom.allowTryMeOut;
+  }
 
   testDataCache[testDataId] = testData;
   return JSON.parse(JSON.stringify(testData));
@@ -154,6 +163,9 @@ export async function sendGraphQLRequest(query, acceptHeader = '') {
         const name = match[1];
         let field;
         if ((name === 'Meeting') && !testData.allowMultipleMeetings) {
+          field = null;
+        }
+        else if ((name === 'Try me out') && !testData.allowTryMeOut) {
           field = null;
         }
         else {

--- a/tools/cli.mjs
+++ b/tools/cli.mjs
@@ -17,6 +17,7 @@ import schedule from './commands/schedule.mjs';
 import synchronizeCalendar from './commands/sync-calendar.mjs';
 import validate from './commands/validate.mjs';
 import viewEvent from './commands/view-event.mjs';
+import tryChanges from './commands/try-changes.mjs';
 
 
 /**
@@ -185,6 +186,30 @@ Usage notes for the options:
   For example:
     $ npx tpac-breakouts --seed mvaksu --changes changes.yml
     $ npx tpac-breakouts --seed tmlnes --apply
+`);
+
+
+/******************************************************************************
+ * The "try-changes" command
+ *****************************************************************************/
+program
+  .command('try-changes')
+  .summary('Try schedule changes in "Try me out" field.')
+  .description('Update the schedule with the meeting changes proposed in the "Try me out" field and report the adjusted grid and validation issues.')
+  .option('-a, --apply', 'apply the adjusted schedule, updating events information on GitHub')
+  .action(getCommandRunner(tryChanges))
+  .addHelpText('after', `
+Output:
+  The command returns the generated schedule grid as HTML content (same structure as the one returned by the \`view\` command). You may want to redirect the output to a file. For example:
+    $ npx tpac-breakouts try-changes > grid.html
+
+  The command also emits warnings to the console to report on progress.
+
+Usage notes for the options:
+-a, --apply
+  When the option is not set, the command merely reports the adjusted schedule.
+
+  When the option is set, the command applies the adjusted schedule, meaning it updates the scheduling information in the GitHub project associated with the event repository. It resets the "Try me out" field accordingly.
 `);
 
 

--- a/tools/commands/try-changes.mjs
+++ b/tools/commands/try-changes.mjs
@@ -15,6 +15,9 @@ export default async function (project, options) {
   console.warn(`Adjust schedule with "Try me out" field...`);
   for (const session of project.sessions) {
     if (session.trymeout) {
+      // TODO: also support "try me out" for breakout sessions,
+      // updating the room, day and slot fields instead of meeting which
+      // does not exist for breakout sessions.
       session.meeting = session.trymeout;
       session.trymeout = null;
       session.updated = true;

--- a/tools/commands/try-changes.mjs
+++ b/tools/commands/try-changes.mjs
@@ -1,0 +1,57 @@
+import { validateGrid } from '../lib/validate.mjs';
+import { saveSessionMeetings } from '../lib/project.mjs';
+import { convertProjectToHTML } from '../lib/project2html.mjs';
+
+export default async function (project, options) {
+  if (!project.allowTryMeOut) {
+    throw new Error(`No "Try me out" custom field in project`);
+  }
+
+  if (!project.sessions.find(session => session.trymeout)) {
+    throw new Error(`No schedule adjustments to try!`);
+  }
+
+  console.warn();
+  console.warn(`Adjust schedule with "Try me out" field...`);
+  for (const session of project.sessions) {
+    if (session.trymeout) {
+      session.meeting = session.trymeout;
+      session.trymeout = null;
+      session.updated = true;
+      console.warn(`- session ${session.number}: from "${session.meeting}" to "${session.trymeout}"`);
+    }
+  }
+  console.warn(`Adjust schedule with "Try me out" field... done`);
+
+  console.warn();
+  console.warn(`Validate created grid...`);
+  const { errors: newErrors } = await validateGrid(project, { what: 'scheduling' })
+  if (newErrors.length) {
+    for (const error of newErrors) {
+      console.warn(`- [${error.severity}: ${error.type}] #${error.session}: ${error.messages.join(', ')}`);
+    }
+  }
+  else {
+    console.warn(`- looks good!`);
+  }
+  console.warn(`Validate created grid... done`);
+
+  console.warn();
+  console.warn(`Report project as HTML...`);
+  const html = await convertProjectToHTML(project);
+  console.warn();
+  console.log(html);
+  console.warn(`Report project as HTML... done`);
+
+  if (options.apply) {
+    console.warn();
+    console.warn(`Apply created grid...`);
+    const sessionsToUpdate = project.sessions.filter(s => s.updated);
+    for (const session of sessionsToUpdate) {
+      console.warn(`- updating #${session.number}...`);
+      await saveSessionMeetings(session, project);
+      console.warn(`- updating #${session.number}... done`);
+    }
+    console.warn(`Apply created grid... done`);
+  }
+}

--- a/tools/lib/validate.mjs
+++ b/tools/lib/validate.mjs
@@ -13,7 +13,8 @@ const schedulingErrors = [
   'warning: capacity',
   'warning: conflict',
   'warning: duration',
-  'warning: track'
+  'warning: track',
+  'warning: times'
 ];
 
 /**


### PR DESCRIPTION
This adds a new `try-changes` command that tries schedule updates defined in a "Try me out" field, as discussed in #115.

The optional `--apply` flag tells the command to apply the adjusted schedule. Applying the adjusted schedule resets the "Try me out" fields.