### PR TITLE
Support non W3C group names in joint meetings too

### DIFF
--- a/test/check-group-unknown.mjs
+++ b/test/check-group-unknown.mjs
@@ -48,4 +48,41 @@ describe('Validation of unknown groups', function () {
     const errors = await validateSession(sessionNumber, project);
     assert.deepStrictEqual(errors, []);
   });
+
+  it('is fine with joint meetings that involves an unknown group explicitly approved (using ",")', async function () {
+    const project = await fetchTestProject();
+    project.w3cIds = { 'WHATWG': 'ok' };
+    const sessionNumber = 3;
+    const errors = await validateSession(sessionNumber, project);
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('is fine with joint meetings that involves an unknown group explicitly approved (using "&")', async function () {
+    const project = await fetchTestProject();
+    project.w3cIds = { 'WHATWG': 'ok' };
+    const sessionNumber = 4;
+    const errors = await validateSession(sessionNumber, project);
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('is fine with joint meetings that involves an unknown group explicitly approved (using "and")', async function () {
+    const project = await fetchTestProject();
+    project.w3cIds = { 'WHATWG': 'ok' };
+    const sessionNumber = 5;
+    const errors = await validateSession(sessionNumber, project);
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('reports an error when title of a joint meeting does not end with "Joint meeting"', async function () {
+    const project = await fetchTestProject();
+    project.w3cIds = { 'WHATWG': 'ok' };
+    const sessionNumber = 6;
+    const errors = await validateSession(sessionNumber, project);
+    assert.deepStrictEqual(errors, [{
+      session: sessionNumber,
+      severity: 'error',
+      type: 'groups',
+      messages: ['Joint meeting found but the title does not end with "Joint Meeting"']
+    }]);
+  });
 });

--- a/test/check-tpac-scheduling.mjs
+++ b/test/check-tpac-scheduling.mjs
@@ -62,6 +62,8 @@ const nonW3CGroupMeetings = {
 };
 
 describe('Scheduling of TPAC meetings', function () {
+  this.timeout(10000);
+
   before(function () {
     initTestEnv();
     setEnvKey('PROJECT_NUMBER', 'tpac2023');

--- a/test/data/group-unknown.mjs
+++ b/test/data/group-unknown.mjs
@@ -10,6 +10,26 @@ export default {
     {
       number: 2,
       title: 'The Not Heavily Working Group'
+    },
+
+    {
+      number: 3,
+      title: 'WHATWG, Media WG Joint Meeting'
+    },
+
+    {
+      number: 4,
+      title: 'WHATWG & Media WG Joint Meeting'
+    },
+
+    {
+      number: 5,
+      title: 'WHATWG and Media WG Joint Meeting'
+    },
+
+    {
+      number: 6,
+      title: 'WHATWG and Media WG'
     }
   ]
 }

--- a/tools/lib/validate.mjs
+++ b/tools/lib/validate.mjs
@@ -162,7 +162,7 @@ ${projectErrors.map(error => '- ' + error).join('\n')}`);
         messages: groupsErrors
       });
     }
-    else if (session.title.match(/ Joint Meeting$/i)) {
+    else if (session.title.trim().match(/ Joint Meeting$/i)) {
       // TODO: validate that groups appear no more than once in the list
       if (session.groups.length === 1) {
         errors.push({
@@ -172,6 +172,14 @@ ${projectErrors.map(error => '- ' + error).join('\n')}`);
           messages: ['Group cannot have a joint meeting with itself']
         });
       }
+    }
+    else if (session.groups.length > 1) {
+      errors.push({
+        session: sessionNumber,
+        severity: 'error',
+        type: 'groups',
+        messages: ['Joint meeting found but the title does not end with "Joint Meeting"']
+      });
     }
     else if (session.groups.length === 1) {
       const duplSessions = project.sessions.filter(s =>

--- a/tools/lib/w3c.mjs
+++ b/tools/lib/w3c.mjs
@@ -88,23 +88,23 @@ function normalizeGroup(group) {
 
   // Hardcode a few exceptions
   if (group.abbrName === 'technical architecture group') {
-    group.alias = 'TAG';
+    group.alias = ['TAG'];
     group.label += ' (TAG)';
   }
   else if (group.abbrName === 'web platform incubator') {
-    group.alias = 'WICG';
+    group.alias = ['WICG'];
     group.label += ' (WICG)';
   }
   else if (group.abbrName === 'cascading style sheets (css)') {
     group.abbrName = 'cascading style sheets';
-    group.alias = 'css';
+    group.alias = ['CSS WG', 'Cascading Style Sheets WG'];
   }
   else if (group.abbrName === 'privacy') {
-    group.alias = 'ping';
+    group.alias = ['ping'];
     group.label += ' (PING)';
   }
   else if (group.abbrName === 'web real-time communications') {
-    group.alias = 'webrtc';
+    group.alias = ['WebRTC WG'];
   }
 
   return group;


### PR DESCRIPTION
The code expected joint meetings would only involve known W3C groups, but there may be joint meetings with other groups in practice (e.g., "WHATWG & CSS WG").

This update is a rewrite of the function that converts an issue title to a list of groups. The function now consumes the title in chunks.

(This should also fix the "CSS" case, making use of the full name, name without "(CSS)", or simply "CSS" possible)