### PR TITLE
Add groups view to generated HTML page

### DIFF
--- a/test/data/ref-breakouts-day-2024.html
+++ b/test/data/ref-breakouts-day-2024.html
@@ -40,6 +40,7 @@
       .capacity-error { background-color: #fcebbd; color: #af9540; }
       .track-error { background-color: #e1f2fa; color: #5992aa; }
       .scheduling-error { background-color: #f5ab9e; color: #8c3a2b; }
+      .scheduling-warning { background-color: #fcebbd; color: #8c3a2b; }
       .track {
         display: inline-block;
         background-color: #0E8A16;

--- a/test/data/ref-group-meetings.html
+++ b/test/data/ref-group-meetings.html
@@ -40,6 +40,7 @@
       .capacity-error { background-color: #fcebbd; color: #af9540; }
       .track-error { background-color: #e1f2fa; color: #5992aa; }
       .scheduling-error { background-color: #f5ab9e; color: #8c3a2b; }
+      .scheduling-warning { background-color: #fcebbd; color: #8c3a2b; }
       .track {
         display: inline-block;
         background-color: #0E8A16;
@@ -498,6 +499,168 @@
             </tr>
           </tbody>
         </table>
+      </section>
+    </section>
+    <section id="groups">
+      <h2>Groups view</h2>
+      <section id="g134685">
+        <h3>Anti-Fraud CG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="g110716">
+        <h3>Audio CG</h3>
+        <ul>
+          <li>Monday, 11:00 - 16:00 (Room 4), joint meeting with Audio Description CG</li>
+          <li>Monday, 14:00 - 16:00 (Room 3)</li>
+        </ul>
+        <ul class="scheduling-error">
+          <li>Session scheduled at the same time as "Audio CG & Audio Description CG joint meeting" (#16), which shares group Audio CG</li>
+          <li>Session scheduled at the same time as "Audio Community Group" (#15), which shares group Audio CG</li>
+        </ul>
+      </section>
+      <section id="g106721">
+        <h3>Audio Description CG</h3>
+        <ul>
+          <li>Monday, 11:00 - 16:00 (Room 4), joint meeting with Audio CG</li>
+        </ul>
+        <ul class="scheduling-error">
+          <li>Session scheduled at the same time as "Audio Community Group" (#15), which shares group Audio CG</li>
+        </ul>
+      </section>
+      <section id="g119681">
+        <h3>Cognitive AI CG</h3>
+        <ul>
+          <li>Monday, 16:00 - 18:00 (Room 1)</li>
+        </ul>
+        <ul class="scheduling-warning">
+          <li>Same day/slot "Monday (2042-02-10) 16:00 - 18:00" as conflicting session "Color on the Web Community Group" (#18)</li>
+        </ul>
+      </section>
+      <section id="g96574">
+        <h3>Color on the Web CG</h3>
+        <ul>
+          <li>Monday, 16:00 - 18:00 (Room 2)</li>
+        </ul>
+      </section>
+      <section id="g127555">
+        <h3>Consent CG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="g72898">
+        <h3>Credentials CG</h3>
+        <ul>
+          <li>Thursday, 16:00 - 18:00 (Room 1)</li>
+        </ul>
+        <ul class="scheduling-error">
+          <li>Same IRC channel "#debug" as session #21 "Credible Web Community Group"</li>
+        </ul>
+      </section>
+      <section id="g103073">
+        <h3>Credible Web CG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="gundefined">
+        <h3>Fantasy WG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="g96877">
+        <h3>GPU for the Web CG</h3>
+        <ul>
+          <li>Tuesday, 9:00 - 18:00 (Room 6)</li>
+          <li>Thursday, 14:00 - 18:00 (Room 6)</li>
+          <li>Thursday, 9:00 - 11:00 (Room 6)</li>
+          <li>Friday, 11:00 - 13:00 (Room 6)</li>
+          <li>Friday, 16:00 - 18:00 (Room 6)</li>
+        </ul>
+      </section>
+      <section id="g49726">
+        <h3>Games CG</h3>
+        <ul>
+          <li>Monday, 9:00 - 16:00 (Room 5)</li>
+        </ul>
+        <ul class="scheduling-warning">
+          <li>Same day/slot "Monday (2042-02-10) 14:00 - 16:00" as session in same track "track: debug": "Generative AI CG" (#23)</li>
+        </ul>
+      </section>
+      <section id="g148246">
+        <h3>Generative AI CG</h3>
+        <ul>
+          <li>Monday, 14:00 - 16:00 (Room 6)</li>
+        </ul>
+        <ul class="scheduling-warning">
+          <li>Same day/slot "Monday (2042-02-10) 14:00 - 16:00" as session in same track "track: debug": "Games CG" (#22)</li>
+        </ul>
+      </section>
+      <section id="g109735">
+        <h3>Immersive Web WG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="g103226">
+        <h3>Improving Web Advertising BG</h3>
+        <ul>
+          <li>Monday, 11:00 - 13:00 (Room 3)</li>
+          <li>Monday, 9:00 - 11:00 (Room 2)</li>
+        </ul>
+        <ul class="scheduling-error">
+          <li>Session scheduled in same room (Room 2) and same day/slot (Monday (2042-02-10) 9:00 - 11:00) as session "Publishing BG" (12)</li>
+        </ul>
+      </section>
+      <section id="g49174">
+        <h3>JSON for Linking Data CG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="g115198">
+        <h3>Media WG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="g97159">
+        <h3>Publishing BG</h3>
+        <ul>
+          <li>Monday, 9:00 - 13:00 (Room 2)</li>
+        </ul>
+        <ul class="scheduling-error">
+          <li>Session scheduled in same room (Room 2) and same day/slot (Monday (2042-02-10) 9:00 - 11:00) as session "Improving Web Advertising Business Group" (13)</li>
+        </ul>
+      </section>
+      <section id="g138751">
+        <h3>RDF Dataset Canonicalization and Hash WG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="g67710">
+        <h3>Second Screen CG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="g74168">
+        <h3>Second Screen WG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="g45211">
+        <h3>Web Performance WG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="g47318">
+        <h3>Web Real-Time Communications WG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="g95969">
+        <h3>Web of Things WG</h3>
+        <p>No meeting scheduled</p>
+      </section>
+      <section id="g101196">
+        <h3>WebAssembly WG</h3>
+        <ul>
+          <li>2020-02-11, 11:00 - 13:00 (Room 1)</li>
+          <li>Tuesday, 9:00 - 11:00 (Room 1)</li>
+        </ul>
+      </section>
+      <section id="g125908">
+        <h3>WebTransport WG</h3>
+        <ul>
+          <li>Monday, 9:00 - 11:00 (Room 1)</li>
+        </ul>
+        <ul class="scheduling-error">
+          <li>Invalid room, day or slot in "Invalid room"</li>
+        </ul>
       </section>
     </section>
     <section id="todo">

--- a/test/data/ref-session-validation.html
+++ b/test/data/ref-session-validation.html
@@ -40,6 +40,7 @@
       .capacity-error { background-color: #fcebbd; color: #af9540; }
       .track-error { background-color: #e1f2fa; color: #5992aa; }
       .scheduling-error { background-color: #f5ab9e; color: #8c3a2b; }
+      .scheduling-warning { background-color: #fcebbd; color: #8c3a2b; }
       .track {
         display: inline-block;
         background-color: #0E8A16;

--- a/test/data/ref-tpac2023.html
+++ b/test/data/ref-tpac2023.html
@@ -40,6 +40,7 @@
       .capacity-error { background-color: #fcebbd; color: #af9540; }
       .track-error { background-color: #e1f2fa; color: #5992aa; }
       .scheduling-error { background-color: #f5ab9e; color: #8c3a2b; }
+      .scheduling-warning { background-color: #fcebbd; color: #8c3a2b; }
       .track {
         display: inline-block;
         background-color: #0E8A16;
@@ -1244,6 +1245,418 @@
             </tr>
           </tbody>
         </table>
+      </section>
+    </section>
+    <section id="groups">
+      <h2>Groups view</h2>
+      <section id="g93339">
+        <h3>Accessibility Conformance Testing (ACT) TF</h3>
+        <ul>
+          <li>Thursday, 09:30 - 18:30 (Prado)</li>
+          <li>Friday, 09:30 - 18:30 (Prado)</li>
+        </ul>
+      </section>
+      <section id="g35532">
+        <h3>Accessibility Education and Outreach WG</h3>
+        <ul>
+          <li>Monday, 17:00 - 18:30 (Utrera)</li>
+          <li>Tuesday, 09:30 - 18:30 (Utrera)</li>
+        </ul>
+      </section>
+      <section id="g35422">
+        <h3>Accessibility Guidelines WG</h3>
+        <ul>
+          <li>Monday, 09:30 - 18:30 (Bambu)</li>
+          <li>Tuesday, 09:30 - 18:30 (Bambu)</li>
+          <li>Thursday, 09:30 - 18:30 (Bambu)</li>
+          <li>Friday, 09:30 - 18:30 (Bambu)</li>
+        </ul>
+      </section>
+      <section id="g83907">
+        <h3>Accessible Platform Architectures WG</h3>
+        <ul>
+          <li>Monday, 09:30 - 18:30 (Ficus)</li>
+          <li>Tuesday, 09:30 - 18:30 (Ficus)</li>
+          <li>Thursday, 09:30 - 16:30 (Ficus)</li>
+        </ul>
+      </section>
+      <section id="g83726">
+        <h3>Accessible Rich Internet Applications WG</h3>
+        <ul>
+          <li>Monday, 09:30 - 18:30 (Estepa)</li>
+          <li>Tuesday, 09:30 - 13:00 (Estepa)</li>
+          <li>Friday, 09:30 - 11:00 (Estepa)</li>
+        </ul>
+      </section>
+      <section id="g33280">
+        <h3>Advisory Committee</h3>
+        <ul>
+          <li>Tuesday, 14:30 - 16:30 (Giralda I)</li>
+        </ul>
+      </section>
+      <section id="g134685">
+        <h3>Anti-Fraud CG</h3>
+        <ul>
+          <li>Tuesday, 14:30 - 16:30 (Estepa)</li>
+          <li>Thursday, 11:30 - 13:00 (Estepa)</li>
+        </ul>
+      </section>
+      <section id="g46884">
+        <h3>Audio WG</h3>
+        <ul>
+          <li>Monday, 11:30 - 13:00 (Giralda III)</li>
+          <li>Tuesday, 11:30 - 13:00 (Giralda III)</li>
+          <li>Thursday, 11:30 - 13:00 (Giralda III)</li>
+          <li>Friday, 11:30 - 13:00 (Giralda III)</li>
+        </ul>
+      </section>
+      <section id="g139357">
+        <h3>Audiovisual Media Formats for Browsers CG</h3>
+        <ul>
+          <li>Thursday, 09:30 - 11:00 (Estepa)</li>
+        </ul>
+      </section>
+      <section id="g143201">
+        <h3>Autonomous Agents on the Web CG</h3>
+        <ul>
+          <li>Monday, 09:30 - 11:00 (Ecija)</li>
+          <li>Monday, 11:30 - 13:00 (Nervion I), joint meeting with Web of Things WG</li>
+        </ul>
+      </section>
+      <section id="g49799">
+        <h3>Browser Testing and Tools WG</h3>
+        <ul>
+          <li>Thursday, 09:30 - 18:30 (Lebrija)</li>
+          <li>Friday, 09:30 - 18:30 (Lebrija)</li>
+        </ul>
+      </section>
+      <section id="g32061">
+        <h3>Cascading Style Sheets (CSS) WG</h3>
+        <ul>
+          <li>Thursday, 09:30 - 18:30 (Azalea)</li>
+          <li>Friday, 09:30 - 18:30 (Azalea)</li>
+        </ul>
+      </section>
+      <section id="g109611">
+        <h3>Chinese Web IG</h3>
+        <ul>
+          <li>Friday, 09:30 - 13:00 (Ficus)</li>
+        </ul>
+      </section>
+      <section id="g117488">
+        <h3>Decentralized Identifier WG</h3>
+        <ul>
+          <li>Tuesday, 09:30 - 13:00 (Ecija)</li>
+        </ul>
+      </section>
+      <section id="g43696">
+        <h3>Devices and Sensors WG</h3>
+        <ul>
+          <li>Thursday, 09:30 - 18:30 (Magnolia)</li>
+        </ul>
+      </section>
+      <section id="g132274">
+        <h3>Federated Identity CG</h3>
+        <ul>
+          <li>Monday, 11:30 - 13:00 (Triana)</li>
+          <li>Tuesday, 09:30 - 11:00 (Triana)</li>
+          <li>Thursday, 09:30 - 13:00 (Triana)</li>
+        </ul>
+      </section>
+      <section id="g109735">
+        <h3>Immersive Web WG</h3>
+        <ul>
+          <li>Monday, 14:30 - 18:30 (Triana)</li>
+          <li>Tuesday, 14:30 - 18:30 (Triana)</li>
+          <li>Friday, 11:30 - 16:30 (Triana)</li>
+        </ul>
+      </section>
+      <section id="g32113">
+        <h3>Internationalization WG</h3>
+        <ul>
+          <li>Monday, 09:30 - 18:30 (Arenal I)</li>
+          <li>Tuesday, 09:30 - 18:30 (Arenal I)</li>
+        </ul>
+      </section>
+      <section id="g49174">
+        <h3>JSON for Linking Data CG</h3>
+        <ul>
+          <li>Monday, 14:30 - 16:30 (Nervion-Arenal II), joint meeting with Web of Things WG, RDF Dataset Canonicalization and Hash WG</li>
+        </ul>
+        <ul class="scheduling-warning">
+          <li>Capacity of "Nervion-Arenal II" (39) is lower than requested capacity (40)</li>
+        </ul>
+      </section>
+      <section id="g35549">
+        <h3>Math WG</h3>
+        <ul>
+          <li>Thursday, 17:00 - 18:30 (Giralda III)</li>
+        </ul>
+      </section>
+      <section id="g115198">
+        <h3>Media WG</h3>
+        <ul>
+          <li>Monday, 14:30 - 18:30 (Azalea)</li>
+          <li>Thursday, 14:30 - 16:30 (Triana), joint meeting with Web Real-Time Communications WG</li>
+        </ul>
+      </section>
+      <section id="g46300">
+        <h3>Media and Entertainment IG</h3>
+        <ul>
+          <li>Monday, 09:30 - 13:00 (Azalea)</li>
+        </ul>
+      </section>
+      <section id="g128558">
+        <h3>MiniApps WG</h3>
+        <ul>
+          <li>Thursday, 09:30 - 13:00 (Ecija)</li>
+        </ul>
+      </section>
+      <section id="g59096">
+        <h3>Pointer Events WG</h3>
+        <ul>
+          <li>Thursday, 17:00 - 18:30 (Ficus)</li>
+        </ul>
+      </section>
+      <section id="g52497">
+        <h3>Privacy IG</h3>
+        <ul>
+          <li>Tuesday, 17:00 - 18:30 (Estepa)</li>
+        </ul>
+      </section>
+      <section id="g134161">
+        <h3>Private Advertising Technology CG</h3>
+        <ul>
+          <li>Monday, 09:30 - 11:00 (Giralda I)</li>
+          <li>Monday, 14:30 - 16:30 (Magnolia)</li>
+        </ul>
+        <ul class="scheduling-warning">
+          <li>Capacity of "Magnolia" (39) is lower than requested capacity (40)</li>
+        </ul>
+      </section>
+      <section id="g144835">
+        <h3>Publishing Maintenance WG</h3>
+        <ul>
+          <li>Monday, 14:30 - 18:30 (Nervion I)</li>
+          <li>Tuesday, 09:30 - 13:00 (Nervion I)</li>
+        </ul>
+      </section>
+      <section id="g138751">
+        <h3>RDF Dataset Canonicalization and Hash WG</h3>
+        <ul>
+          <li>Monday, 09:30 - 13:00 (Utrera)</li>
+          <li>Monday, 14:30 - 16:30 (Nervion-Arenal II), joint meeting with JSON for Linking Data CG, Web of Things WG</li>
+        </ul>
+        <ul class="scheduling-warning">
+          <li>Capacity of "Nervion-Arenal II" (39) is lower than requested capacity (40)</li>
+        </ul>
+      </section>
+      <section id="g139681">
+        <h3>RDF-star WG</h3>
+        <ul>
+          <li>Tuesday, 09:30 - 18:30 (Giralda V)</li>
+        </ul>
+      </section>
+      <section id="g141487">
+        <h3>Screen Capture CG</h3>
+        <ul>
+          <li>Thursday, 14:30 - 16:30 (Giralda III)</li>
+          <li>Thursday, 17:00 - 18:30 (Triana), joint meeting with Web Real-Time Communications WG</li>
+        </ul>
+      </section>
+      <section id="g74168">
+        <h3>Second Screen WG</h3>
+        <ul>
+          <li>Friday, 14:30 - 18:30 (Ficus)</li>
+        </ul>
+      </section>
+      <section id="gclosed">
+        <h3>Semantic Industries CG</h3>
+        <ul>
+          <li>Tuesday, 14:30 - 16:30 (Giralda III)</li>
+          <li>Tuesday, 17:00 - 18:30 (Lebrija)</li>
+        </ul>
+      </section>
+      <section id="g-1">
+        <h3>SocialWeb CG</h3>
+        <ul>
+          <li>Tuesday, 09:30 - 11:00 (Giralda III)</li>
+        </ul>
+      </section>
+      <section id="g110151">
+        <h3>Solid CG</h3>
+        <ul>
+          <li>Monday, 17:00 - 18:30 (Ecija)</li>
+        </ul>
+      </section>
+      <section id="g34270">
+        <h3>Technical Architecture Group</h3>
+        <ul>
+          <li>Monday, 09:30 - 13:00 (Giralda V)</li>
+          <li>Friday, 14:30 - 18:30 (Giralda V)</li>
+        </ul>
+      </section>
+      <section id="g34314">
+        <h3>Timed Text WG</h3>
+        <ul>
+          <li>Tuesday, 09:30 - 18:30 (Prado)</li>
+        </ul>
+      </section>
+      <section id="g98922">
+        <h3>Verifiable Credentials WG</h3>
+        <ul>
+          <li>Thursday, 09:30 - 18:30 (Arenal I)</li>
+          <li>Friday, 09:30 - 18:30 (Arenal I)</li>
+        </ul>
+      </section>
+      <section id="gBFF">
+        <h3>W3C Chapters and Evangelists</h3>
+        <ul>
+          <li>Thursday, 09:30 - 18:30 (Nervion-Arenal II)</li>
+        </ul>
+      </section>
+      <section id="g-1">
+        <h3>WHATWG</h3>
+        <ul>
+          <li>Thursday, 09:30 - 18:30 (Utrera)</li>
+          <li>Friday, 09:30 - 18:30 (Utrera)</li>
+        </ul>
+      </section>
+      <section id="g115035">
+        <h3>Web & Networks IG</h3>
+        <ul>
+          <li>Monday, 14:30 - 16:30 (Giralda V)</li>
+        </ul>
+      </section>
+      <section id="g49309">
+        <h3>Web Application Security WG</h3>
+        <ul>
+          <li>Thursday, 14:30 - 18:30 (Nervion I)</li>
+          <li>Friday, 14:30 - 18:30 (Nervion I)</li>
+        </ul>
+      </section>
+      <section id="g114929">
+        <h3>Web Applications WG</h3>
+        <ul>
+          <li>Monday, 09:30 - 13:00 (Santa Cruz)</li>
+          <li>Monday, 14:30 - 18:30 (Giralda I)</li>
+          <li>Tuesday, 09:30 - 13:00 (Santa Cruz)</li>
+          <li>Tuesday, 14:30 - 16:30 (Magnolia)</li>
+          <li>Tuesday, 17:00 - 18:30 (Giralda I)</li>
+        </ul>
+        <ul class="scheduling-warning">
+          <li>Capacity of "Magnolia" (39) is lower than requested capacity (40)</li>
+        </ul>
+      </section>
+      <section id="g87227">
+        <h3>Web Authentication WG</h3>
+        <ul>
+          <li>Monday, 09:30 - 11:00 (Nervion I)</li>
+          <li>Tuesday, 14:30 - 16:30 (Nervion I)</li>
+        </ul>
+      </section>
+      <section id="g131776">
+        <h3>Web Editing WG</h3>
+        <ul>
+          <li>Thursday, 09:30 - 18:30 (Santa Cruz)</li>
+        </ul>
+      </section>
+      <section id="g44556">
+        <h3>Web Fonts WG</h3>
+        <ul>
+          <li>Tuesday, 09:30 - 18:30 (Azalea)</li>
+        </ul>
+      </section>
+      <section id="g113649">
+        <h3>Web Payment Security IG</h3>
+        <ul>
+          <li>Thursday, 09:30 - 18:30 (Giralda V)</li>
+        </ul>
+      </section>
+      <section id="g83744">
+        <h3>Web Payments WG</h3>
+        <ul>
+          <li>Monday, 09:30 - 18:30 (Lebrija)</li>
+          <li>Tuesday, 09:30 - 16:30 (Lebrija)</li>
+        </ul>
+      </section>
+      <section id="g45211">
+        <h3>Web Performance WG</h3>
+        <ul>
+          <li>Monday, 11:30 - 16:30 (Ecija)</li>
+          <li>Tuesday, 14:30 - 18:30 (Ecija)</li>
+          <li>Thursday, 14:30 - 18:30 (Ecija)</li>
+          <li>Friday, 11:30 - 16:30 (Ecija)</li>
+        </ul>
+      </section>
+      <section id="g80485">
+        <h3>Web Platform Incubator CG</h3>
+        <ul>
+          <li>Monday, 14:30 - 18:30 (Santa Cruz)</li>
+          <li>Tuesday, 14:30 - 18:30 (Santa Cruz)</li>
+          <li>Friday, 14:30 - 18:30 (Santa Cruz)</li>
+        </ul>
+      </section>
+      <section id="g-1">
+        <h3>Web Platform Tests</h3>
+        <ul>
+          <li>Tuesday, 09:30 - 13:00 (Magnolia)</li>
+        </ul>
+      </section>
+      <section id="g47318">
+        <h3>Web Real-Time Communications WG</h3>
+        <ul>
+          <li>Tuesday, 11:30 - 16:30 (Nervion-Arenal II)</li>
+          <li>Thursday, 14:30 - 16:30 (Triana), joint meeting with Media WG</li>
+          <li>Thursday, 17:00 - 18:30 (Triana), joint meeting with Screen Capture CG</li>
+        </ul>
+      </section>
+      <section id="g63991">
+        <h3>Web of Things CG</h3>
+        <ul>
+          <li>Thursday, 11:30 - 13:00 (Nervion I)</li>
+          <li>Friday, 11:30 - 13:00 (Nervion I)</li>
+        </ul>
+      </section>
+      <section id="g75874">
+        <h3>Web of Things IG</h3>
+        <ul>
+          <li>Thursday, 14:30 - 18:30 (Estepa), joint meeting with Web of Things WG</li>
+          <li>Friday, 14:30 - 18:30 (Estepa), joint meeting with Web of Things WG</li>
+        </ul>
+      </section>
+      <section id="g95969">
+        <h3>Web of Things WG</h3>
+        <ul>
+          <li>Monday, 11:30 - 13:00 (Nervion I), joint meeting with Autonomous Agents on the Web CG</li>
+          <li>Monday, 14:30 - 16:30 (Nervion-Arenal II), joint meeting with JSON for Linking Data CG, RDF Dataset Canonicalization and Hash WG</li>
+          <li>Thursday, 14:30 - 18:30 (Estepa), joint meeting with Web of Things IG</li>
+          <li>Friday, 14:30 - 18:30 (Estepa), joint meeting with Web of Things IG</li>
+        </ul>
+        <ul class="scheduling-warning">
+          <li>Capacity of "Nervion-Arenal II" (39) is lower than requested capacity (40)</li>
+        </ul>
+      </section>
+      <section id="g122873">
+        <h3>WebAuthn Adoption CG</h3>
+        <ul>
+          <li>Tuesday, 11:30 - 13:00 (Giralda I)</li>
+          <li>Thursday, 11:30 - 13:00 (Giralda I)</li>
+          <li>Friday, 11:30 - 16:30 (Giralda I)</li>
+        </ul>
+      </section>
+      <section id="g131613">
+        <h3>WebExtensions CG</h3>
+        <ul>
+          <li>Monday, 17:00 - 18:30 (Giralda III)</li>
+          <li>Tuesday, 17:00 - 18:30 (Giralda III)</li>
+        </ul>
+      </section>
+      <section id="g125908">
+        <h3>WebTransport WG</h3>
+        <ul>
+          <li>Tuesday, 17:00 - 18:30 (Nervion I)</li>
+        </ul>
       </section>
     </section>
     


### PR DESCRIPTION
The grid view is great to look at the schedule. Groups may be more interested in a short summary for themselves. This update adds a groups view next to the grid in the generated HTML page.

The groups view also lists all warnings and errors that got raised against the sessions related to the underlying group.