### PR TITLE
Support the concept of "VIP" rooms

### DIFF
--- a/test/check-vip-room.mjs
+++ b/test/check-vip-room.mjs
@@ -1,0 +1,59 @@
+import * as assert from 'node:assert';
+import { readFile, writeFile } from 'node:fs/promises';
+import { initTestEnv } from './init-test-env.mjs';
+import { getEnvKey, setEnvKey } from '../tools/lib/envkeys.mjs';
+import { fetchProject, convertProjectToJSON } from '../tools/lib/project.mjs';
+import { validateSession, validateGrid } from '../tools/lib/validate.mjs';
+import { suggestSchedule } from '../tools/lib/schedule.mjs';
+import { convertProjectToHTML } from '../tools/lib/project2html.mjs';
+
+async function fetchTestProject() {
+  const project = await fetchProject(
+    await getEnvKey('PROJECT_OWNER'),
+    await getEnvKey('PROJECT_NUMBER'));
+  return project;
+}
+
+function stripDetails(errors) {
+  return errors.map(err => {
+    if (err.details) {
+      delete err.details;
+    }
+    return err;
+  });
+}
+
+describe('The VIP system', function () {
+  before(function () {
+    initTestEnv();
+    setEnvKey('PROJECT_NUMBER', 'vip-room');
+    setEnvKey('ISSUE_TEMPLATE', 'test/data/template-group.yml');
+  });
+
+  it('schedules VIP/non-VIP groups to VIP/non-VIP rooms', async function () {
+    const project = await fetchTestProject();
+    const { errors } = await validateGrid(project);
+    assert.deepStrictEqual(errors, []);
+
+    suggestSchedule(project, { seed: 'schedule' });
+
+    let { errors: scheduleErrors } = await validateGrid(project);
+    scheduleErrors = scheduleErrors.filter(error => error.severity === 'error');
+    assert.deepStrictEqual(scheduleErrors, []);
+
+    for (const session of project.sessions) {
+      if (session.number === 1) {
+        assert.strictEqual(session.room, 'Business (25) (VIP)',
+          `VIP group ${session.number} scheduled in non-VIP room ${session.room}`);
+      }
+      else if (session.slot && session.room) {
+        assert.strictEqual(session.room, 'Economy (25)',
+          `Non-VIP group ${session.number} scheduled in VIP room ${session.room}`);
+      }
+    }
+
+    const unscheduled = project.sessions.filter(s => !s.meeting && (!s.room || !s.slot));
+    assert.strictEqual(unscheduled.length, 1,
+      `Expected one non-scheduled non-VIP group, but got ${unscheduled.length}`);
+  });
+});

--- a/test/data/vip-room.mjs
+++ b/test/data/vip-room.mjs
@@ -1,0 +1,40 @@
+export default {
+  description: 'meeting: Validation of "VIP" rooms, timezone: Etc/UTC, type: groups',
+
+  days: [
+    '2042-04-05'
+  ],
+
+  slots: [
+    '9:00 - 10:00',
+    '10:00 - 11:00'
+  ],
+
+  rooms: [
+    'Business (25) (VIP)',
+    'Economy (25)'
+  ],
+
+  sessions: [
+    {
+      number: 1,
+      title: 'Advisory Committee',
+      room: 'Business (25) (VIP)'
+    },
+
+    {
+      number: 2,
+      title: 'Second Screen WG'
+    },
+
+    {
+      number: 3,
+      title: 'Media WG'
+    },
+
+    {
+      number: 4,
+      title: 'GPU for the Web WG'
+    }
+  ]
+};

--- a/tools/lib/project.mjs
+++ b/tools/lib/project.mjs
@@ -759,20 +759,28 @@ export async function fetchProject(login, id) {
     metadata: parseProjectDescription(project.shortDescription),
 
     // List of rooms. For each of them, we return the exact name of the option
-    // for the "Room" custom field in the project (which should include the
-    // room's capacity), the actual name of the room without the capacity, and
-    // the room's capacity in number of seats.
+    // for the "Room" custom field in the project (which includes all info),
+    // the actual room label, the room's capacity in number of seats, the
+    // location of the room, and the possible "vip" flag.
+    // The room's full name should follow the pattern:
+    //   "label (xx - location) (vip)"
+    // Examples:
+    //  Catalina (25)
+    //  Utrecht (40 - 2nd floor)
+    //  Main (120) (vip)
+    //  Business (vip)
+    //  Small (15)
+    //  Plenary (150 - 18th floor) (vip)
     roomsFieldId: rooms.id,
     rooms: rooms.options.map(room => {
-      const match =
-        room.name.match(/(.*) \((\d+)\s*(?:\-\s*([^\)]+))?\)$/) ??
-        [room.name, room.name, '30', undefined];
+      const match = room.name.match(/^(.*?)(?:\s*\((\d+)\s*(?:\-\s*([^\)]+))?\))?(?:\s*\((vip)\))?$/i);
       return {
         id: room.id,
         name: match[0],
         label: match[1],
         location: match[3] ?? '',
-        capacity: parseInt(match[2], 10)
+        capacity: parseInt(match[2] ?? '30', 10),
+        vip: !!match[4]
       };
     }),
 

--- a/tools/lib/schedule.mjs
+++ b/tools/lib/schedule.mjs
@@ -347,11 +347,13 @@ export function suggestSchedule(project, { seed }) {
       else {
         // All rooms that have enough capacity are candidate rooms
         possibleRooms.push(...rooms
+          .filter(room => !room.vip)
           .filter(room => room.name !== plenaryRoom || session.description.type === 'plenary')
           .filter(room => room.capacity >= (session.description.capacity ?? 0))
           .sort(byCapacity));
         if (!meetCapacity) {
           possibleRooms.push(...rooms
+            .filter(room => !room.vip)
             .filter(room => room.name !== plenaryRoom || session.description.type === 'plenary')
             .filter(room => room.capacity < (session.description.capacity ?? +Infinity))
             .sort(byCapacityDesc));


### PR DESCRIPTION
Via #128. Some rooms may be dedicated to specific meetings, especially at TPAC. To implement the functionality, rooms may now be defined with an addition "(vip)" flag, as in: "Business room (75) (vip)" or "Plenary (VIP)". Casing does not matter.

When the "(vip)" flag is set to a room's name, the scheduler no longer assigns sessions to that room. A session may still explicitly be tied to a VIP room through the `Room` field.

This mechanism can be used to add a room dedicated to the Advisory Committee meeting.