### PR TITLE
Fix calendar sync

### DIFF
--- a/tools/commands/sync-calendar.mjs
+++ b/tools/commands/sync-calendar.mjs
@@ -12,6 +12,13 @@ export default async function (project, number, options) {
     throw new Error(`Invalid argument passed as parameter. Expected "all" or a session number and got "${number}"`);
   }
 
+  if (options.status?.toLowerCase() === 'no' ||
+      !project.metadata.calendar ||
+      project.metadata.calendar.toLowerCase() === 'no') {
+    console.warn('Nothing to do, synchronization with W3C calendar is disabled. To enable synchronization, set the `--status` command-line option or the "calendar" setting in the project\'s description.');
+    return;
+  }
+
   console.warn(`Retrieve environment variables...`);
   const CALENDAR_SERVER = await getEnvKey('CALENDAR_SERVER', 'www.w3.org');
   console.warn(`- CALENDAR_SERVER: ${CALENDAR_SERVER}`);
@@ -47,7 +54,7 @@ export default async function (project, number, options) {
           calendarServer: CALENDAR_SERVER,
           login: W3C_LOGIN,
           password: W3C_PASSWORD,
-          status: options.status,
+          status: options.status ?? project.metadata.calendar,
           roomZoom: project.roomZoom
         });
         console.warn(`Convert session ${session.number} to calendar entries... done`);
@@ -94,7 +101,7 @@ export default async function (project, number, options) {
         calendarServer: CALENDAR_SERVER,
         login: W3C_LOGIN,
         password: W3C_PASSWORD,
-        status: options.status,
+        status: options.status ?? project.metadata.calendar,
         roomZoom: project.roomZoom
       });
       console.warn(`Convert session ${session.number} to calendar entries... done`);

--- a/tools/lib/calendar.mjs
+++ b/tools/lib/calendar.mjs
@@ -346,7 +346,7 @@ async function fillCalendarEntry({ page, entry, session, project, status, zoom }
 
   const room = (project.metadata.rooms === 'hide') ?
     null :
-    project.rooms.find(room => room.name === entry.room);
+    project.rooms.find(room => room.name === entry.meeting.room);
   const roomLocation = (room?.label ?? '') + (room?.location ? ' - ' + room.location : '');
   await fillTextInput('input#event_location', roomLocation ?? '');
 
@@ -600,9 +600,9 @@ export async function synchronizeSessionWithCalendar(
   // sessions in the same plenary. To avoid creating a mess in the calendar,
   // we'll throw if one of these sessions has an error that needs fixing.
   if (session.description.type === 'plenary') {
-    const meeting = actions.update[0] ?? actions.create[0];
+    const meetingEntry = actions.update[0] ?? actions.create[0];
     const sessions = project.sessions
-      .filter(s => s !== session && meetsAt(s, meeting, project));
+      .filter(s => s !== session && meetsAt(s, meetingEntry.meeting, project));
     for (const s of sessions) {
       const errors = (await validateSession(s, project))
         .filter(error => error.severity === 'error');
@@ -647,8 +647,8 @@ export async function synchronizeSessionWithCalendar(
   }
 
   for (const entry of actions.update) {
-    console.log(`- refresh calendar entry ${entry.url}, meeting in ${entry.room} on ${entry.day} ${entry.start} - ${entry.end}`);
-    const room = project.rooms.find(room => room.name === entry.room);
+    console.log(`- refresh calendar entry ${entry.url}, meeting in ${entry.meeting.room} on ${entry.day} ${entry.start} - ${entry.end}`);
+    const room = project.rooms.find(room => room.name === entry.meeting.room);
     const zoom = project.metadata.rooms === 'hide' ? null : roomZoom[room.label];
     entry.url = await updateCalendarEntry({
       calendarUrl: entry.url,
@@ -658,8 +658,8 @@ export async function synchronizeSessionWithCalendar(
   }
 
   for (const entry of actions.create) {
-    console.log(`- create new calendar entry, meeting in ${entry.room} on ${entry.day} ${entry.start} - ${entry.end}`);
-    const room = project.rooms.find(room => room.name === entry.room);
+    console.log(`- create new calendar entry, meeting in ${entry.meeting.room} on ${entry.day} ${entry.start} - ${entry.end}`);
+    const room = project.rooms.find(room => room.name === entry.meeting.room);
     const zoom = project.metadata.rooms === 'hide' ? null : roomZoom[room.label];
     entry.url = await updateCalendarEntry({
       calendarUrl: null,

--- a/tools/lib/project.mjs
+++ b/tools/lib/project.mjs
@@ -991,6 +991,10 @@ export function validateProject(project) {
     if (!['groups', 'breakouts', undefined].includes(project.metadata?.type)) {
       errors.push('The "type" info must be one of "groups" or "breakouts"');
     }
+    if (project.metadata.calendar &&
+        !['no', 'draft', 'tentative', 'confirmed'].includes(project.metadata.calendar)) {
+      errors.push('The "calendar" info must be one of "no", "draft", "tentative" or "confirmed"');
+    }
   }
 
   for (const slot of project.slots) {


### PR DESCRIPTION
The calendar synchronization tool was supposed not to do anything when
`--status` is set to "no" or when it is not set and there is no "calendar"
setting at the project level (or that setting is itself set to "no").

In practice, it did not handle the "no" value properly and did not fallback to
the "calendar" project's setting. This should fix the problem, reporting a
"Nothing to do" message to the console when synchronization is disabled.

Also, the CLI expected the room's name to be readily available under
a calendar's entry, but there's an intermediary `meeting` level to access the
room in practice.