### PR TITLE
Support group meetings with highlights

### DIFF
--- a/test/check-group-highlight.mjs
+++ b/test/check-group-highlight.mjs
@@ -4,6 +4,8 @@ import { getEnvKey, setEnvKey } from '../tools/lib/envkeys.mjs';
 import { fetchProject, validateProject } from '../tools/lib/project.mjs';
 import { validateSession } from '../tools/lib/validate.mjs';
 import { groupSessionMeetings } from '../tools/lib/meetings.mjs';
+import { convertProjectToHTML } from '../tools/lib/project2html.mjs';
+import { readFile, writeFile } from 'node:fs/promises';
 
 async function fetchTestProject() {
   return fetchProject(
@@ -13,6 +15,18 @@ async function fetchTestProject() {
 
 function toGroupNames(groups) {
   return groups ? groups.map(group => group.name) : [];
+}
+
+async function assertSameAsRef(html) {
+  const refName = await getEnvKey('PROJECT_NUMBER');
+  const refFilename = `test/data/ref-${refName}.html`;
+  const updateRef = await getEnvKey('UPDATE_REFS', false);
+  if (updateRef) {
+    await writeFile(refFilename, html, 'utf8');
+  }
+  const refHtml = (await readFile(refFilename, 'utf8'))
+    .replace(/\r/g, '');
+  assert.strictEqual(html, refHtml);
 }
 
 describe('The group meetings highlight code', function () {
@@ -70,6 +84,20 @@ describe('The group meetings highlight code', function () {
       ['Second Screen WG', 'Media WG']);
   });
 
+  it('reports an error when meeting is only an highlight', async function () {
+    const project = await fetchTestProject();
+    const sessionNumber = 6;
+    const errors = await validateSession(sessionNumber, project);
+    assert.deepStrictEqual(errors, [{
+      session: 6,
+      severity: 'error',
+      type: 'groups',
+      messages: [
+        'No group associated with the issue'
+      ]
+    }]);
+  });
+
   it('does not merge meetings when an highlight is used in one of them', async function () {
     const project = await fetchTestProject();
     const errors = await validateProject(project);
@@ -91,5 +119,11 @@ describe('The group meetings highlight code', function () {
         day: 'Monday (2042-02-10)'
       }
     ]);
+  });
+
+  it('reports highlights in the group view in the generated HTML page', async function () {
+    const project = await fetchTestProject();
+    const html = await convertProjectToHTML(project);
+    await assertSameAsRef(html);
   });
 });

--- a/test/check-group-highlight.mjs
+++ b/test/check-group-highlight.mjs
@@ -1,0 +1,95 @@
+import * as assert from 'node:assert';
+import { initTestEnv } from './init-test-env.mjs';
+import { getEnvKey, setEnvKey } from '../tools/lib/envkeys.mjs';
+import { fetchProject, validateProject } from '../tools/lib/project.mjs';
+import { validateSession } from '../tools/lib/validate.mjs';
+import { groupSessionMeetings } from '../tools/lib/meetings.mjs';
+
+async function fetchTestProject() {
+  return fetchProject(
+    await getEnvKey('PROJECT_OWNER'),
+    await getEnvKey('PROJECT_NUMBER'));
+}
+
+function toGroupNames(groups) {
+  return groups ? groups.map(group => group.name) : [];
+}
+
+describe('The group meetings highlight code', function () {
+  before(function () {
+    initTestEnv();
+    setEnvKey('PROJECT_NUMBER', 'group-highlight');
+    setEnvKey('ISSUE_TEMPLATE', 'test/data/template-group.yml');
+  });
+
+  it('finds the group name from a title with highlight (":")', async function () {
+    const project = await fetchTestProject();
+    const sessionNumber = 1;
+    const errors = await validateSession(sessionNumber, project);
+    assert.deepStrictEqual(errors, []);
+
+    const session = project.sessions.find(s => s.number === sessionNumber);
+    assert.deepStrictEqual(
+      toGroupNames(session.groups),
+      ['Web Platform Incubator CG']);
+  });
+
+  it('finds the group name from a title with highlight (">")', async function () {
+    const project = await fetchTestProject();
+    const sessionNumber = 4;
+    const errors = await validateSession(sessionNumber, project);
+    assert.deepStrictEqual(errors, []);
+
+    const session = project.sessions.find(s => s.number === sessionNumber);
+    assert.deepStrictEqual(
+      toGroupNames(session.groups),
+      ['Second Screen WG']);
+  });
+
+  it('does not get confused by a ":" in the group name', async function () {
+    const project = await fetchTestProject();
+    const sessionNumber = 3;
+    const errors = await validateSession(sessionNumber, project);
+    assert.deepStrictEqual(errors, []);
+
+    const session = project.sessions.find(s => s.number === sessionNumber);
+    assert.deepStrictEqual(
+      toGroupNames(session.groups),
+      ['WAI-Engage: Web Accessibility CG']);
+  });
+
+  it('finds group names from a joint meeting title with highlight', async function () {
+    const project = await fetchTestProject();
+    const sessionNumber = 5;
+    const errors = await validateSession(sessionNumber, project);
+    assert.deepStrictEqual(errors, []);
+
+    const session = project.sessions.find(s => s.number === sessionNumber);
+    assert.deepStrictEqual(
+      toGroupNames(session.groups),
+      ['Second Screen WG', 'Media WG']);
+  });
+
+  it('does not merge meetings when an highlight is used in one of them', async function () {
+    const project = await fetchTestProject();
+    const errors = await validateProject(project);
+
+    const sessionNumber = 2;
+    const session = project.sessions.find(s => s.number === sessionNumber);
+    const merged = groupSessionMeetings(session, project);
+    assert.deepStrictEqual(merged, [
+      {
+        start: '9:00',
+        end: '11:00',
+        room: 'Room 1',
+        day: 'Monday (2042-02-10)'
+      },
+      {
+        start: '14:00',
+        end: '16:00',
+        room: 'Room 1',
+        day: 'Monday (2042-02-10)'
+      }
+    ]);
+  });
+});

--- a/test/check-group-unknown.mjs
+++ b/test/check-group-unknown.mjs
@@ -73,7 +73,7 @@ describe('Validation of unknown groups', function () {
     assert.deepStrictEqual(errors, []);
   });
 
-  it('reports an error when title of a joint meeting does not end with "Joint meeting"', async function () {
+  it('reports an error when title of a joint meeting does not have "Joint meeting"', async function () {
     const project = await fetchTestProject();
     project.w3cIds = { 'WHATWG': 'ok' };
     const sessionNumber = 6;
@@ -82,7 +82,7 @@ describe('Validation of unknown groups', function () {
       session: sessionNumber,
       severity: 'error',
       type: 'groups',
-      messages: ['Joint meeting found but the title does not end with "Joint Meeting"']
+      messages: ['Joint meeting found but the title does not have "Joint Meeting"']
     }]);
   });
 });

--- a/test/data/group-highlight.mjs
+++ b/test/data/group-highlight.mjs
@@ -1,0 +1,56 @@
+export default {
+  allowMultipleMeetings: true,
+  description: 'meeting: Group meeting highlights, timezone: Etc/UTC, type: groups',
+
+  days: [
+    'Monday (2042-02-10)'
+  ],
+
+  slots: [
+    '9:00 - 11:00',
+    '11:00 - 13:00',
+    '14:00 - 16:00'
+  ],
+
+  rooms: [
+    'Room 1',
+    'Room 2'
+  ],
+
+  sessions: [
+    {
+      number: 1,
+      title: 'WICG: Digital Credentials API',
+      room: 'Room 1',
+      meeting: 'Monday, 11:00'
+    },
+
+    {
+      number: 2,
+      title: 'Web Platform Incubator CG',
+      room: 'Room 1',
+      meeting: 'Monday, 9:00; Monday, 14:00'
+    },
+
+    {
+      number: 3,
+      title: 'WAI-Engage: Web Accessibility Community Group',
+      room: 'Room 2',
+      meeting: 'Monday, 9:00'
+    },
+
+    {
+      number: 4,
+      title: 'Second Screen WG > OSP',
+      room: 'Room 2',
+      meeting: 'Monday, 11:00'
+    },
+
+    {
+      number: 5,
+      title: 'Second Screen WG & Media WG Joint Meeting: Media streaming',
+      room: 'Room 2',
+      meeting: 'Monday, 14:00'
+    }
+  ]
+}

--- a/test/data/group-highlight.mjs
+++ b/test/data/group-highlight.mjs
@@ -14,7 +14,8 @@ export default {
 
   rooms: [
     'Room 1',
-    'Room 2'
+    'Room 2',
+    'Room 3'
   ],
 
   sessions: [
@@ -51,6 +52,13 @@ export default {
       title: 'Second Screen WG & Media WG Joint Meeting: Media streaming',
       room: 'Room 2',
       meeting: 'Monday, 14:00'
+    },
+
+    {
+      number: 6,
+      title: '> Just an highlight',
+      room: 'Room 3',
+      meeting: 'Monday, 9:00'
     }
   ]
 }

--- a/test/data/ref-group-highlight.html
+++ b/test/data/ref-group-highlight.html
@@ -1,0 +1,244 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    
+    <title>Group meeting highlights - Event schedule</title>
+    <style>
+      /* Table styles and colors adapted from Pure CSS:
+       * https://github.com/pure-css/pure
+       * ... under a BSD License:
+       * https://github.com/pure-css/pure/blob/master/LICENSE
+       */
+      table {
+        border-collapse: collapse;
+        border-spacing: 0;
+        empty-cells: show;
+        border: 1px solid #cbcbcb;
+      }
+      table caption {
+        color: #000;
+        font: italic 85%/1 arial, sans-serif;
+        padding: 1em 0;
+        text-align: center;
+      }
+      table td,
+      table th {
+        border-left: 1px solid #cbcbcb;
+        border-bottom: 1px solid #cbcbcb;
+        border-width: 0 0 1px 1px;
+        font-size: inherit;
+        margin: 0;
+        overflow: visible;
+        padding: 0.5em 1em;
+      }
+      table thead {
+        background-color: #e0e0e0;
+        color: #000;
+        text-align: left;
+        vertical-align: bottom;
+      }
+      .conflict-error { background-color: #ddaeff; color: #8156a7; }
+      .capacity-error { background-color: #fcebbd; color: #af9540; }
+      .track-error { background-color: #e1f2fa; color: #5992aa; }
+      .scheduling-error { background-color: #f5ab9e; color: #8c3a2b; }
+      .scheduling-warning { background-color: #fcebbd; color: #8c3a2b; }
+      .track {
+        display: inline-block;
+        background-color: #0E8A16;
+        color: white;
+        border: 1px transparent;
+        border-radius: 1em;
+        margin-top: 0.2em;
+        margin-bottom: 0.2em;
+        padding: 3px 10px;
+        font-size: smaller;
+        white-space: nowrap;
+      }
+      .nbrooms { font-weight: normal; }
+    </style>
+    <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/base.css" type="text/css"/>
+  </head>
+  <body>
+    <h1>Group meeting highlights</h1>
+    <section id="overview">
+      <h2>Sessions overview</h2>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th>Not scheduled</th>
+            <th>Scheduled</th>
+            <th>Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>Format errors</th>
+            <td>0</td>
+            <td>0</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <th>Validation errors</th>
+            <td>0</td>
+            <td>1</td>
+            <td>1</td>
+          </tr>
+          <tr>
+            <th>Validation warnings</th>
+            <td>0</td>
+            <td>0</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <th>Feel good sessions</th>
+            <td>0</td>
+            <td>5</td>
+            <td>5</td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <th>Total</th>
+            <td>0</td>
+            <td>6</td>
+            <td>6</td>
+          </tr>
+        </tfoot>
+      </table>
+    </section>
+    <section id="schedule">
+      <h2>Schedule</h2>
+      <section id="d2042-02-10">
+        <h3>Monday (2042-02-10)</h3>
+        <table>
+          <thead>
+            <tr>
+              <th></th>
+              <th>Room 1</th>
+              <th>Room 2</th>
+              <th>Room 3</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>
+                9:00 - 11:00
+                <p class="nbrooms">3 meetings</p>
+              </th>
+              <td class="">
+                <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/2">#2</a></b>: Web Platform Incubator CG
+                </p>
+              </td>
+              <td class="">
+                <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/3">#3</a></b>: WAI-Engage: Web Accessibility Community Group
+                </p>
+              </td>
+              <td class="">
+                <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/6">#6</a></b>: > Just an highlight
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                11:00 - 13:00
+                <p class="nbrooms">2 meetings</p>
+              </th>
+              <td class="">
+                <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/1">#1</a></b>: WICG: Digital Credentials API
+                </p>
+              </td>
+              <td class="">
+                <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/4">#4</a></b>: Second Screen WG > OSP
+                </p>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <th>
+                14:00 - 16:00
+                <p class="nbrooms">2 meetings</p>
+              </th>
+              <td class="">
+                <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/2">#2</a></b>: Web Platform Incubator CG
+                </p>
+              </td>
+              <td class="">
+                <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/5">#5</a></b>: Second Screen WG & Media WG Joint Meeting: Media streaming
+                </p>
+              </td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+    <section id="groups">
+      <h2>Groups view</h2>
+      <section id="g115198">
+        <h3>Media WG</h3>
+        <ul>
+          <li>Monday, 14:00 - 16:00 (Room 2), joint meeting with Second Screen WG, topic: Media streaming (#5)</li>
+        </ul>
+      </section>
+      <section id="g74168">
+        <h3>Second Screen WG</h3>
+        <ul>
+          <li>Monday, 11:00 - 13:00 (Room 2), topic: OSP (#4)</li>
+          <li>Monday, 14:00 - 16:00 (Room 2), joint meeting with Media WG, topic: Media streaming (#5)</li>
+        </ul>
+      </section>
+      <section id="g54291">
+        <h3>WAI-Engage: Web Accessibility CG</h3>
+        <ul>
+          <li>Monday, 9:00 - 11:00 (Room 2) (#3)</li>
+        </ul>
+      </section>
+      <section id="g80485">
+        <h3>Web Platform Incubator CG</h3>
+        <ul>
+          <li>Monday, 11:00 - 13:00 (Room 1), topic: Digital Credentials API (#1)</li>
+          <li>Monday, 14:00 - 16:00 (Room 1) (#2)</li>
+          <li>Monday, 9:00 - 11:00 (Room 1) (#2)</li>
+        </ul>
+      </section>
+    </section>
+    <section id="yaml">
+      <h2>Data for Saving/Restoring Schedule</h2>
+      <pre id="data">
+- number: 1
+  reset: all
+  room: Room 1
+  meeting:
+    - Monday, 11:00
+- number: 2
+  reset: all
+  room: Room 1
+  meeting:
+    - Monday, 9:00
+    - Monday, 14:00
+- number: 3
+  reset: all
+  room: Room 2
+  meeting:
+    - Monday, 9:00
+- number: 4
+  reset: all
+  room: Room 2
+  meeting:
+    - Monday, 11:00
+- number: 5
+  reset: all
+  room: Room 2
+  meeting:
+    - Monday, 14:00
+- number: 6
+  reset: all
+  room: Room 3
+  meeting:
+    - Monday, 9:00
+
+      </pre>
+    </section>
+  </body>
+</html>

--- a/tools/lib/project2html.mjs
+++ b/tools/lib/project2html.mjs
@@ -425,11 +425,15 @@ export async function convertProjectToHTML(project, cliParams) {
           const room = project.rooms.find(room => room.name === meeting.room);
           const session = groupMeeting.session;
           let jointStr = '';
+          let highlightStr = '';
           if (session.groups.length > 1) {
             const groups = session.groups.filter(g => g.name !== name);
             jointStr = `, joint meeting with ` + groups.map(g => g.name).join(', ');
           }
-          writeLine(5, `<li>${day.label}, ${meeting.start} - ${meeting.end}${reduce ? '' : ' (' + room.label + ')'}${jointStr} (#${session.number})</li>`);
+          if (session.highlight) {
+            highlightStr = `, topic: ${session.highlight}`;
+          }
+          writeLine(5, `<li>${day.label}, ${meeting.start} - ${meeting.end}${reduce ? '' : ' (' + room.label + ')'}${jointStr}${highlightStr} (#${session.number})</li>`);
         }
         writeLine(4, `</ul>`);
       }


### PR DESCRIPTION
See description in #137.

This draft pull request adds functional tests for the feature, but does not yet implement the feature.

A couple of tests already pass. They must not start failing once the feature gets implemented. That should be a no-brainer for the second one, because the code that merges meetings of a group already proceeds on a session by session basis and cannot merge meetings that belong to two different sessions.

Note validation logic will need to be updated because it does not expect to find two sessions for the same group and will report an error accordingly.