### PR TITLE
Add new "switch" warning to alert on room changes

### DIFF
--- a/test/check-group-meetings.mjs
+++ b/test/check-group-meetings.mjs
@@ -146,6 +146,21 @@ describe('The group meetings module', function () {
     }]);
   });
 
+  it('warns about room switches', async function () {
+    const project = await fetchTestProject();
+    const sessionNumber = 25;
+    const errors = await validateSession(sessionNumber, project);
+    assert.deepStrictEqual(stripDetails(errors), [{
+      session: sessionNumber,
+      severity: 'warning',
+      type: 'switch',
+      messages: [
+        'Room switch between "Room 7" and "Room 8" on Tuesday at 11:00',
+        'Room switch between "Room 8" and "Room 7" on Tuesday at 14:00'
+      ]
+    }]);
+  });
+
   it('reports an error when a group needs to be at two places at once', async function () {
     const project = await fetchTestProject();
     const sessionNumber = 15;

--- a/test/data/group-meetings.mjs
+++ b/test/data/group-meetings.mjs
@@ -25,7 +25,9 @@ export default {
     'Room 3',
     'Room 4',
     'Room 5',
-    'Room 6'
+    'Room 6',
+    'Room 7',
+    'Room 8'
   ],
 
   w3cAccounts: {
@@ -238,6 +240,15 @@ Check contiguous slots merge and links to calendar
 - [Monday, 9:00 - 18:00](https://example.com/calendar/6)`,
       room: 'Room 6',
       meeting: 'Tuesday, 14:00; Tuesday, 11:00; Tuesday, 9:00; Thursday, 9:00; Tuesday, 16:00; Thursday, 16:00; Thursday, 14:00; Friday, 11:00; Friday, 16:00'
+    },
+
+    {
+      number: 25,
+      title: 'RDF-star Working Group',
+      body: `
+### Session description
+Check warning on different rooms with contiguous slots`,
+      meeting: 'Tuesday, 9:00, Room 7; Tuesday, 11:00, Room 8; Tuesday, 14:00, Room 7; Thursday, 9:00, Room 8'
     }
   ]
 }

--- a/test/data/ref-group-meetings.html
+++ b/test/data/ref-group-meetings.html
@@ -87,8 +87,8 @@
           <tr>
             <th>Validation warnings</th>
             <td>1</td>
-            <td>3</td>
             <td>4</td>
+            <td>5</td>
           </tr>
           <tr>
             <th>Feel good sessions</th>
@@ -101,8 +101,8 @@
           <tr>
             <th>Total</th>
             <td>12</td>
-            <td>12</td>
-            <td>24</td>
+            <td>13</td>
+            <td>25</td>
           </tr>
         </tfoot>
       </table>
@@ -121,6 +121,8 @@
               <th>Room 4</th>
               <th>Room 5</th>
               <th>Room 6</th>
+              <th>Room 7</th>
+              <th>Room 8</th>
             </tr>
           </thead>
           <tbody>
@@ -129,6 +131,8 @@
                 9:00 - 11:00
                 <p class="nbrooms">0 meetings</p>
               </th>
+              <td></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -150,6 +154,8 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
+              <td></td>
             </tr>
             <tr>
               <th>
@@ -162,12 +168,16 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
+              <td></td>
             </tr>
             <tr>
               <th>
                 16:00 - 18:00
                 <p class="nbrooms">0 meetings</p>
               </th>
+              <td></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -190,6 +200,8 @@
               <th>Room 4</th>
               <th>Room 5</th>
               <th>Room 6</th>
+              <th>Room 7</th>
+              <th>Room 8</th>
             </tr>
           </thead>
           <tbody>
@@ -216,6 +228,8 @@
                 </p>
               </td>
               <td></td>
+              <td></td>
+              <td></td>
             </tr>
             <tr>
               <th>
@@ -229,6 +243,7 @@
               </td>
               <td class="">
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/13">#13</a></b>: Improving Web Advertising Business Group
+                <br/><b>Previous slot in</b>: <span class="scheduling-warning">Room 2</span>
                 </p>
               </td>
               <td class="">
@@ -240,6 +255,8 @@
                 <br/><span class="track">track: debug</span>
                 </p>
               </td>
+              <td></td>
+              <td></td>
               <td></td>
             </tr>
             <tr>
@@ -269,6 +286,8 @@
                 <br/><span class="track">track: debug</span>
                 </p>
               </td>
+              <td></td>
+              <td></td>
             </tr>
             <tr>
               <th>
@@ -284,6 +303,8 @@
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/18">#18</a></b>: Color on the Web Community Group
                 </p>
               </td>
+              <td></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -304,13 +325,15 @@
               <th>Room 4</th>
               <th>Room 5</th>
               <th>Room 6</th>
+              <th>Room 7</th>
+              <th>Room 8</th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <th>
                 9:00 - 11:00
-                <p class="nbrooms">2 meetings</p>
+                <p class="nbrooms">3 meetings</p>
               </th>
               <td class="">
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/11">#11</a></b>: WebAssembly Working Group
@@ -324,11 +347,16 @@
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/24">#24</a></b>: GPU for the Web Community Group
                 </p>
               </td>
+              <td class="">
+                <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/25">#25</a></b>: RDF-star Working Group
+                </p>
+              </td>
+              <td></td>
             </tr>
             <tr>
               <th>
                 11:00 - 13:00
-                <p class="nbrooms">1 meetings</p>
+                <p class="nbrooms">2 meetings</p>
               </th>
               <td></td>
               <td></td>
@@ -337,13 +365,19 @@
               <td></td>
               <td class="">
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/24">#24</a></b>: GPU for the Web Community Group
+                </p>
+              </td>
+              <td></td>
+              <td class="">
+                <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/25">#25</a></b>: RDF-star Working Group
+                <br/><b>Previous slot in</b>: <span class="scheduling-warning">Room 7</span>
                 </p>
               </td>
             </tr>
             <tr>
               <th>
                 14:00 - 16:00
-                <p class="nbrooms">1 meetings</p>
+                <p class="nbrooms">2 meetings</p>
               </th>
               <td></td>
               <td></td>
@@ -354,6 +388,12 @@
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/24">#24</a></b>: GPU for the Web Community Group
                 </p>
               </td>
+              <td class="">
+                <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/25">#25</a></b>: RDF-star Working Group
+                <br/><b>Previous slot in</b>: <span class="scheduling-warning">Room 8</span>
+                </p>
+              </td>
+              <td></td>
             </tr>
             <tr>
               <th>
@@ -369,6 +409,8 @@
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/24">#24</a></b>: GPU for the Web Community Group
                 </p>
               </td>
+              <td></td>
+              <td></td>
             </tr>
           </tbody>
         </table>
@@ -385,13 +427,15 @@
               <th>Room 4</th>
               <th>Room 5</th>
               <th>Room 6</th>
+              <th>Room 7</th>
+              <th>Room 8</th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <th>
                 9:00 - 11:00
-                <p class="nbrooms">1 meetings</p>
+                <p class="nbrooms">2 meetings</p>
               </th>
               <td></td>
               <td></td>
@@ -402,12 +446,19 @@
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/24">#24</a></b>: GPU for the Web Community Group
                 </p>
               </td>
+              <td></td>
+              <td class="">
+                <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/25">#25</a></b>: RDF-star Working Group
+                </p>
+              </td>
             </tr>
             <tr>
               <th>
                 11:00 - 13:00
                 <p class="nbrooms">0 meetings</p>
               </th>
+              <td></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -429,6 +480,8 @@
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/24">#24</a></b>: GPU for the Web Community Group
                 </p>
               </td>
+              <td></td>
+              <td></td>
             </tr>
             <tr>
               <th>
@@ -447,6 +500,8 @@
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/24">#24</a></b>: GPU for the Web Community Group
                 </p>
               </td>
+              <td></td>
+              <td></td>
             </tr>
           </tbody>
         </table>
@@ -463,6 +518,8 @@
               <th>Room 4</th>
               <th>Room 5</th>
               <th>Room 6</th>
+              <th>Room 7</th>
+              <th>Room 8</th>
             </tr>
           </thead>
           <tbody>
@@ -471,6 +528,8 @@
                 9:00 - 11:00
                 <p class="nbrooms">0 meetings</p>
               </th>
+              <td></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -492,12 +551,16 @@
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/24">#24</a></b>: GPU for the Web Community Group
                 </p>
               </td>
+              <td></td>
+              <td></td>
             </tr>
             <tr>
               <th>
                 14:00 - 16:00
                 <p class="nbrooms">0 meetings</p>
               </th>
+              <td></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -519,6 +582,8 @@
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/24">#24</a></b>: GPU for the Web Community Group
                 </p>
               </td>
+              <td></td>
+              <td></td>
             </tr>
           </tbody>
         </table>
@@ -648,6 +713,9 @@
           <li>Monday, 11:00 - 13:00 (Room 3) (#13)</li>
           <li>Monday, 9:00 - 11:00 (Room 2) (#13)</li>
         </ul>
+        <ul class="scheduling-warning">
+          <li><a href="https://github.com/w3c/tpac-breakouts/issues/13">#13</a>: Room switch between "Room 2" and "Room 3" on Monday at 11:00</li>
+        </ul>
         <ul class="scheduling-error">
           <li><a href="https://github.com/w3c/tpac-breakouts/issues/13">#13</a>: Session scheduled in same room (Room 2) and same day/slot (Monday (2042-02-10) 9:00 - 11:00) as session "Publishing BG" (12)</li>
         </ul>
@@ -678,6 +746,19 @@
         <ul class="scheduling-error">
             <li><a href="https://github.com/w3c/tpac-breakouts/issues/8">#8</a>: No meeting scheduled</li>
           </ul>
+      </section>
+      <section id="g139681">
+        <h3>RDF-star WG</h3>
+        <ul>
+          <li>Tuesday, 11:00 - 13:00 (Room 8) (#25)</li>
+          <li>Tuesday, 14:00 - 16:00 (Room 7) (#25)</li>
+          <li>Tuesday, 9:00 - 11:00 (Room 7) (#25)</li>
+          <li>Thursday, 9:00 - 11:00 (Room 8) (#25)</li>
+        </ul>
+        <ul class="scheduling-warning">
+          <li><a href="https://github.com/w3c/tpac-breakouts/issues/25">#25</a>: Room switch between "Room 7" and "Room 8" on Tuesday at 11:00</li>
+          <li><a href="https://github.com/w3c/tpac-breakouts/issues/25">#25</a>: Room switch between "Room 8" and "Room 7" on Tuesday at 14:00</li>
+        </ul>
       </section>
       <section id="g67710">
         <h3>Second Screen CG</h3>
@@ -874,6 +955,13 @@
     - Thursday, 14:00
     - Friday, 11:00
     - Friday, 16:00
+- number: 25
+  reset: all
+  meeting:
+    - Tuesday, 9:00, Room 7
+    - Tuesday, 11:00, Room 8
+    - Tuesday, 14:00, Room 7
+    - Thursday, 9:00, Room 8
 
       </pre>
     </section>

--- a/tools/lib/project2html.mjs
+++ b/tools/lib/project2html.mjs
@@ -340,6 +340,14 @@ export async function convertProjectToHTML(project, cliParams) {
 
             const sessionIssues = cell.errors.filter(error =>
               error.issue.session === session.number);
+            const roomSwitchIssue = sessionIssues.find(error =>
+              error.issue.severity === 'warning' && error.issue.type === 'switch');
+            if (roomSwitchIssue) {
+              const room = project.rooms.find(room => room.name === roomSwitchIssue.detail.previous.room);
+              writeLine(8, '<br/><b>Previous slot in</b>: ' +
+                '<span class="scheduling-warning">' + room.label + '</span>');
+            }
+
             const conflictIssues = sessionIssues
               .filter(error =>
                 error.issue.severity === 'warning' &&


### PR DESCRIPTION
The `warning: switch` warning gets reported when a session needs to switch rooms from one slot to the next. The warning is *not reported* if the room change occurs from one day to the next.

In the HTML schedule page, the warning appears both in the schedule table through a "Previous slot in: [room name]" message and in the "Groups View" section.

See #152.