### PR TITLE
Make scheduler really skip invalid sessions

### DIFF
--- a/test/check-invalid-scheduling.mjs
+++ b/test/check-invalid-scheduling.mjs
@@ -1,0 +1,47 @@
+import * as assert from 'node:assert';
+import { initTestEnv } from './init-test-env.mjs';
+import { getEnvKey, setEnvKey } from '../tools/lib/envkeys.mjs';
+import { fetchProject } from '../tools/lib/project.mjs';
+import { validateGrid } from '../tools/lib/validate.mjs';
+import { suggestSchedule } from '../tools/lib/schedule.mjs';
+import { convertProjectToHTML } from '../tools/lib/project2html.mjs';
+
+async function fetchTestProject() {
+  const project = await fetchProject(
+    await getEnvKey('PROJECT_OWNER'),
+    await getEnvKey('PROJECT_NUMBER'));
+  return project;
+}
+
+function stripDetails(errors) {
+  return errors.map(err => {
+    if (err.details) {
+      delete err.details;
+    }
+    return err;
+  });
+}
+
+describe('When given invalid sessions, the scheduler', function () {
+  before(function () {
+    initTestEnv();
+    setEnvKey('PROJECT_NUMBER', 'session-validation');
+    setEnvKey('ISSUE_TEMPLATE', 'test/data/template-breakout.yml');
+  });
+
+  it('skips invalid sessions', async function () {
+    const project = await fetchTestProject();
+    project.sessions = project.sessions.filter(s => [1, 2, 3].includes(s.number));
+    await validateGrid(project);
+
+    const session1 = project.sessions.find(s => s.number === 1);
+    const session2 = project.sessions.find(s => s.number === 2);
+    const session3 = project.sessions.find(s => s.number === 3);
+    session2.blockingError = true;
+    suggestSchedule(project, { seed: 'schedule' });
+
+    assert.deepStrictEqual(session1.meetings, undefined);
+    assert.deepStrictEqual(session2.meetings, undefined);
+    assert.deepStrictEqual(session3.meetings?.length, 1);
+  });
+});

--- a/test/check-tpac-scheduling.mjs
+++ b/test/check-tpac-scheduling.mjs
@@ -2,7 +2,7 @@ import * as assert from 'node:assert';
 import { readFile, writeFile } from 'node:fs/promises';
 import { initTestEnv } from './init-test-env.mjs';
 import { getEnvKey, setEnvKey } from '../tools/lib/envkeys.mjs';
-import { fetchProject, convertProjectToJSON } from '../tools/lib/project.mjs';
+import { fetchProject } from '../tools/lib/project.mjs';
 import { validateSession, validateGrid } from '../tools/lib/validate.mjs';
 import { suggestSchedule } from '../tools/lib/schedule.mjs';
 import { convertProjectToHTML } from '../tools/lib/project2html.mjs';

--- a/test/check-vip-room.mjs
+++ b/test/check-vip-room.mjs
@@ -1,9 +1,8 @@
 import * as assert from 'node:assert';
-import { readFile, writeFile } from 'node:fs/promises';
 import { initTestEnv } from './init-test-env.mjs';
 import { getEnvKey, setEnvKey } from '../tools/lib/envkeys.mjs';
-import { fetchProject, convertProjectToJSON } from '../tools/lib/project.mjs';
-import { validateSession, validateGrid } from '../tools/lib/validate.mjs';
+import { fetchProject } from '../tools/lib/project.mjs';
+import { validateGrid } from '../tools/lib/validate.mjs';
 import { suggestSchedule } from '../tools/lib/schedule.mjs';
 import { convertProjectToHTML } from '../tools/lib/project2html.mjs';
 

--- a/tools/commands/schedule.mjs
+++ b/tools/commands/schedule.mjs
@@ -28,6 +28,9 @@ export default async function (project, options) {
     error.type !== 'irc');
   const validSessions = project.sessions.filter(s =>
     !errors.find(error => error.number === s.number));
+  project.sessions
+    .filter(s => errors.find(error => error.number === s.number))
+    .forEach(s => s.blockingError = true);
   console.warn(`- found ${validSessions.length} valid sessions among them: ${validSessions.map(s => s.number).join(', ')}`);
   console.warn(`Validate sessions... done`);
 

--- a/tools/lib/schedule.mjs
+++ b/tools/lib/schedule.mjs
@@ -74,8 +74,8 @@ export function suggestSchedule(project, { seed }) {
 
   // Filter out invalid sessions
   sessions = sessions.filter(session =>
-    !session.blockingErrors ||
-    (session.blockingErrors.length === 0));
+    session.description &&
+    !session.blockingError);
 
   // Initialize the list of tracks
   // Note: for the purpose of scheduling, a "_plenary" track gets artificially


### PR DESCRIPTION
The scheduler expected that invalid sessions would be flagged with a `blockingErrors` property, but that property was never set. The schedule command now sets a `blockingError` flag, and the scheduler is slightly more resilient on invalid sessions.