### PR TITLE
Handle expanded group names in sessions with highlights

### DIFF
--- a/test/check-group-highlight.mjs
+++ b/test/check-group-highlight.mjs
@@ -98,6 +98,18 @@ describe('The group meetings highlight code', function () {
     }]);
   });
 
+  it('finds group names even when no acronym is used', async function () {
+    const project = await fetchTestProject();
+    const sessionNumber = 7;
+    const errors = await validateSession(sessionNumber, project);
+    assert.deepStrictEqual(errors, []);
+
+    const session = project.sessions.find(s => s.number === sessionNumber);
+    assert.deepStrictEqual(
+      toGroupNames(session.groups),
+      ['Web Payments WG']);
+  });
+
   it('does not merge meetings when an highlight is used in one of them', async function () {
     const project = await fetchTestProject();
     const errors = await validateProject(project);

--- a/test/data/group-highlight.mjs
+++ b/test/data/group-highlight.mjs
@@ -59,6 +59,13 @@ export default {
       title: '> Just an highlight',
       room: 'Room 3',
       meeting: 'Monday, 9:00'
+    },
+
+    {
+      number: 7,
+      title: 'Web Payments Working Group: money money money',
+      room: 'Room 3',
+      meeting: 'Monday, 11:00'
     }
   ]
 }

--- a/test/data/ref-group-highlight.html
+++ b/test/data/ref-group-highlight.html
@@ -93,16 +93,16 @@
           <tr>
             <th>Feel good sessions</th>
             <td>0</td>
-            <td>5</td>
-            <td>5</td>
+            <td>6</td>
+            <td>6</td>
           </tr>
         </tbody>
         <tfoot>
           <tr>
             <th>Total</th>
             <td>0</td>
-            <td>6</td>
-            <td>6</td>
+            <td>7</td>
+            <td>7</td>
           </tr>
         </tfoot>
       </table>
@@ -142,7 +142,7 @@
             <tr>
               <th>
                 11:00 - 13:00
-                <p class="nbrooms">2 meetings</p>
+                <p class="nbrooms">3 meetings</p>
               </th>
               <td class="">
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/1">#1</a></b>: WICG: Digital Credentials API
@@ -152,7 +152,10 @@
                 <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/4">#4</a></b>: Second Screen WG > OSP
                 </p>
               </td>
-              <td></td>
+              <td class="">
+                <p><b><a href="https://github.com/w3c/tpac-breakouts/issues/7">#7</a></b>: Web Payments Working Group: money money money
+                </p>
+              </td>
             </tr>
             <tr>
               <th>
@@ -192,6 +195,12 @@
         <h3>WAI-Engage: Web Accessibility CG</h3>
         <ul>
           <li>Monday, 9:00 - 11:00 (Room 2) (#3)</li>
+        </ul>
+      </section>
+      <section id="g83744">
+        <h3>Web Payments WG</h3>
+        <ul>
+          <li>Monday, 11:00 - 13:00 (Room 3), topic: money money money (#7)</li>
         </ul>
       </section>
       <section id="g80485">
@@ -237,6 +246,11 @@
   room: Room 3
   meeting:
     - Monday, 9:00
+- number: 7
+  reset: all
+  room: Room 3
+  meeting:
+    - Monday, 11:00
 
       </pre>
     </section>

--- a/tools/lib/groups.mjs
+++ b/tools/lib/groups.mjs
@@ -16,11 +16,11 @@ import { fetchW3CGroups } from './w3c.mjs';
 export async function fetchSessionGroups(session, groups2W3CID) {
   function normalizeTitle(title) {
     return title
-      .replace(/ (BG|Business Group)($|,| and| &)/gi, ' BG$2')
-      .replace(/ (CG|Community Group)($|,| and| &)/gi, ' CG$2')
-      .replace(/ (IG|Interest Group)($|,| and| &)/gi, ' IG$2')
-      .replace(/ (WG|Working Group)($|,| and| &)/gi, ' WG$2')
-      .replace(/ (TF|Task Force)($|,| and| &)/gi, ' TF$2')
+      .replace(/ (BG|Business Group)($|,| and| &|:|>)/gi, ' BG$2')
+      .replace(/ (CG|Community Group)($|,| and| &|:|>)/gi, ' CG$2')
+      .replace(/ (IG|Interest Group)($|,| and| &|:|>)/gi, ' IG$2')
+      .replace(/ (WG|Working Group)($|,| and| &|:|>)/gi, ' WG$2')
+      .replace(/ (TF|Task Force)($|,| and| &|:|>)/gi, ' TF$2')
       .trim();
   }
 


### PR DESCRIPTION
The code incorrectly took for granted that a session with an highlight would always use acronyms for the types of groups (e.g., "WG" instead of "Working Group"), and failed to recognize the name of the group if the expanded form was used.

While it may be a good idea to keep session titles short, code should still handle the expanded form. Done in this update.