### PR TITLE
Make scheduler start with more constrained sessions first

### DIFF
--- a/test/check-track-schedule-with-constraints.mjs
+++ b/test/check-track-schedule-with-constraints.mjs
@@ -1,0 +1,43 @@
+import * as assert from 'node:assert';
+import { initTestEnv } from './init-test-env.mjs';
+import { getEnvKey, setEnvKey } from '../tools/lib/envkeys.mjs';
+import { fetchProject } from '../tools/lib/project.mjs';
+import { validateGrid } from '../tools/lib/validate.mjs';
+import { suggestSchedule } from '../tools/lib/schedule.mjs';
+
+async function fetchTestProject() {
+  const project = await fetchProject(
+    await getEnvKey('PROJECT_OWNER'),
+    await getEnvKey('PROJECT_NUMBER'));
+  return project;
+}
+
+describe('When given track sessions with constraints, the scheduler', function () {
+  before(function () {
+    initTestEnv();
+    setEnvKey('PROJECT_NUMBER', 'track-schedule-with-constraints');
+    setEnvKey('ISSUE_TEMPLATE', 'test/data/template-breakout.yml');
+  });
+
+  it('priorities the session with time slot constraints', async function () {
+    const project = await fetchTestProject();
+    const { errors } = await validateGrid(project);
+    assert.deepStrictEqual(errors, []);
+    const sessionWithoutConflicts = project.sessions.find(s => s.number === 2);
+    // Who would have thought? The "good" seed actually shuffles the two
+    // sessions in the order we need: 1 first, then 2.
+    suggestSchedule(project, { seed: 'good' });
+    assert.deepStrictEqual(sessionWithoutConflicts.slot, '10:00 - 11:00');
+  });
+
+  it('priorities the session with time slot constraints even when initial order suggests the opposite', async function () {
+    const project = await fetchTestProject();
+    const { errors } = await validateGrid(project);
+    assert.deepStrictEqual(errors, []);
+    const sessionWithoutConflicts = project.sessions.find(s => s.number === 2);
+    // Who would have thought? The "bad" seed actually shuffles the two
+    // sessions in the order we need: 2 first, then 1.
+    suggestSchedule(project, { seed: 'bad' });
+    assert.deepStrictEqual(sessionWithoutConflicts.slot, '10:00 - 11:00');
+  });
+});

--- a/test/data/track-schedule-with-constraints.mjs
+++ b/test/data/track-schedule-with-constraints.mjs
@@ -1,0 +1,88 @@
+export default {
+  description: 'meeting: Scheduling of tracks with sessions that have constraints, timezone: Etc/UTC, ',
+
+  days: [
+    '2042-04-05'
+  ],
+
+  slots: [
+    '9:00 - 10:00',
+    '10:00 - 11:00'
+  ],
+
+  rooms: [
+    'Room 1',
+    'Room 2'
+  ],
+
+  labels: [
+    'session',
+    'track: ux'
+  ],
+
+  sessions: [
+    {
+      number: 1,
+      author: 'ianbjacobs',
+      title: 'Session with constraint',
+      labels: ['session', 'track: ux'],
+      slot: '9:00 - 10:00',
+      body: `
+### Session description
+Blah
+
+### Session goal
+Schedule test
+
+### Session type
+Breakout (Default)
+
+### Additional session chairs (Optional)
+_No response_
+
+### IRC channel (Optional)
+#scheduling
+
+### Other sessions where we should avoid scheduling conflicts (Optional)
+_No response_
+
+### Instructions for meeting planners (Optional)
+_No response_
+
+### Agenda (link or inline) (Optional)
+_No response_
+`
+    },
+    {
+      number: 2,
+      author: 'tidoust',
+      title: 'Session without constraint',
+      labels: ['session', 'track: ux'],
+      body: `
+### Session description
+Blah
+
+### Session goal
+Schedule test
+
+### Session type
+Breakout (Default)
+
+### Additional session chairs (Optional)
+_No response_
+
+### IRC channel (Optional)
+#scheduling
+
+### Other sessions where we should avoid scheduling conflicts (Optional)
+_No response_
+
+### Instructions for meeting planners (Optional)
+_No response_
+
+### Agenda (link or inline) (Optional)
+_No response_
+`
+    }
+  ]
+};


### PR DESCRIPTION
When one of the sessions that belong to a track gets assigned a slot, the scheduler now starts with this session when it schedules the track. This avoids running into situations where the scheduler gets to the session once the slot is already taken.