### PR TITLE
Add code to copy event data to a Google spreadsheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "SEE LICENSE IN 'LICENSE' file",
       "dependencies": {
         "commander": "^12.0.0",
+        "googleapis": "^144.0.0",
         "irc": "^0.5.2",
         "puppeteer": "^23.2.1",
         "seedrandom": "^3.0.5",
@@ -398,6 +399,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -472,6 +482,31 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -675,6 +710,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/degenerator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -703,6 +755,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/emoji-regex": {
@@ -736,6 +797,27 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -811,6 +893,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -923,6 +1011,44 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -930,6 +1056,25 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-stream": {
@@ -996,11 +1141,83 @@
         "node": ">= 6"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.14.2.tgz",
+      "integrity": "sha512-R+FRIfk1GBo3RdlRYWPdwk8nmtVUOn6+BkDomAC46KoU8kzXzE1HLmOasSCbWUByMMAGkknVF0G5kQ69Vj7dlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "144.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-144.0.0.tgz",
+      "integrity": "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -1010,6 +1227,54 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -1226,6 +1491,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -1263,6 +1540,15 @@
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "license": "MIT"
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -1279,6 +1565,27 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/lines-and-columns": {
@@ -1407,6 +1714,26 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-icu-charset-detector": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-icu-charset-detector/-/node-icu-charset-detector-0.2.0.tgz",
@@ -1428,6 +1755,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/once": {
@@ -1650,6 +1989,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-tick": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
@@ -1701,7 +2055,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1744,6 +2097,41 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/smart-buffer": {
@@ -1922,6 +2310,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
@@ -1960,17 +2354,52 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/urlpattern-polyfill": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
       "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/webvtt-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/webvtt-parser/-/webvtt-parser-2.2.0.tgz",
       "integrity": "sha512-FzmaED+jZyt8SCJPTKbSsimrrnQU8ELlViE1wuF3x1pgiQUM8Llj5XWj2j/s6Tlk71ucPfGSMFqZWBtKn/0uEA==",
       "license": "CC0-1.0"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/workerpool": {
       "version": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "commander": "^12.0.0",
+    "googleapis": "^144.0.0",
     "irc": "^0.5.2",
     "puppeteer": "^23.2.1",
     "seedrandom": "^3.0.5",

--- a/tools/cli.mjs
+++ b/tools/cli.mjs
@@ -15,6 +15,7 @@ import { getEnvKey } from './lib/envkeys.mjs';
 import { fetchProject } from './lib/project.mjs';
 import schedule from './commands/schedule.mjs';
 import synchronizeCalendar from './commands/sync-calendar.mjs';
+import synchronizeSheet from './commands/sync-sheet.mjs';
 import validate from './commands/validate.mjs';
 import viewEvent from './commands/view-event.mjs';
 import viewRegisrants from './commands/view-registrants.mjs';
@@ -234,6 +235,33 @@ Notes:
 Examples:
   $ npx tpac-breakouts sync-calendar all --status tentative
   $ npx tpac-breakouts sync-calendar 42 --status confirmed
+`);
+
+
+/******************************************************************************
+ * The "sync-sheet" command
+ *****************************************************************************/
+program
+  .command('sync-sheet')
+  .summary('Synchronize the project with a Google sheet.')
+  .description('Create/Update a Google sheet that contains all project\'s data, including the schedule.')
+  .option('-s, --sheet <id>', 'ID of the Google Sheet to update, "new" to create a new one. Default: value of the GOOGLE_SHEET_ID environment variable.')
+  .option('-d, --drive <id>', 'ID of the Google shared drive in which to create the new sheet')
+  .action(getCommandRunner(synchronizeSheet))
+  .addHelpText('after', `
+Notes:
+  - Local environment must define a \`GOOGLE_KEY_JSON\` variable.
+  The variable must complete the path to a JSON file that contains the
+  private key of a service account with the appropriate rights, created
+  in Google Cloud: https://console.cloud.google.com/.
+
+  - If the --drive option is set while the sheet already exists, the code
+  will try to move the sheet to the provided shared drive. That may not
+  succeed depending on the permissions associated with the key.
+
+Examples:
+  $ npx tpac-breakouts sync-sheet
+  $ npx tpac-breakouts sync-sheet --sheet new
 `);
 
 

--- a/tools/commands/sync-sheet.mjs
+++ b/tools/commands/sync-sheet.mjs
@@ -1,0 +1,36 @@
+import { getEnvKey } from '../lib/envkeys.mjs';
+import { convertProjectToSheet } from '../lib/project2sheet.mjs';
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms, 'slept'));
+}
+
+export default async function (project, options) {
+  console.warn(`Retrieve environment variables...`);
+  const GOOGLE_KEY_FILE = await getEnvKey('GOOGLE_KEY_FILE');
+  console.warn(`- GOOGLE_KEY_FILE: ${GOOGLE_KEY_FILE}`);
+  const GOOGLE_SHEET_ID = await getEnvKey('GOOGLE_SHEET_ID', '');
+  console.warn(`- GOOGLE_SHEET_ID: ${GOOGLE_SHEET_ID ?? 'not set'}`);
+  const GOOGLE_SHARED_DRIVE_ID = await getEnvKey('GOOGLE_SHARED_DRIVE_ID', '');
+  const W3C_LOGIN = await getEnvKey('W3C_LOGIN', '');
+  console.warn(`- W3C_LOGIN: ${W3C_LOGIN ?? 'not set'}`);
+  console.warn(`- GOOGLE_SHARED_DRIVE_ID: ${GOOGLE_SHARED_DRIVE_ID ?? 'not set'}`);
+  console.warn(`Retrieve environment variables... done`);
+
+  console.warn();
+  console.warn(`Create/Update Google sheet...`);
+  const sheetId = options?.sheet && options.sheet !== 'new' ?
+    options.sheet :
+    GOOGLE_SHEET_ID;
+  const driveId = options?.drive ?
+    options.drive :
+    GOOGLE_SHARED_DRIVE_ID;
+  const editorEmail = W3C_LOGIN ? W3C_LOGIN + '@w3.org' : '';
+  await convertProjectToSheet(project, {
+    spreadsheetId: sheetId,
+    driveId,
+    editorEmail,
+    keyFile: GOOGLE_KEY_FILE
+  });
+  console.warn(`Create/Update Google sheet... done`);
+}

--- a/tools/lib/project2sheet.mjs
+++ b/tools/lib/project2sheet.mjs
@@ -1,0 +1,758 @@
+import { convertProjectToJSON } from './project.mjs';
+import { parseSessionMeetings } from './meetings.mjs';
+import { google } from 'googleapis';
+
+/**
+ * Convert the project to a Google Sheet
+ */
+export async function convertProjectToSheet(project,
+    { spreadsheetId, driveId, keyFile, editorEmail } ) {
+  // Authenticate through a service token
+  const auth = new google.auth.GoogleAuth({
+    keyFile,
+    scopes: [
+      'https://www.googleapis.com/auth/drive',
+      'https://www.googleapis.com/auth/drive.file',
+      'https://www.googleapis.com/auth/spreadsheets',
+    ],
+  });
+  const authClient = await auth.getClient();
+
+  const sheets = google.sheets({
+    version: 'v4',
+    auth: authClient
+  });
+
+  /**
+   * Inner function to create the spreadsheet if it does not exist yet
+   */
+  async function createSpreadsheet() {
+    const now = new Date();
+    const nowPrefix = now.toISOString()
+      .substring(0, 'YYYY-MM-DDTHH:mm:ss'.length)
+      .replace(/[-:]/g, '');
+    let res = await sheets.spreadsheets.create({
+      resource: {
+        properties: {
+          title: nowPrefix + ' - '+ project.title
+        },
+        sheets: [
+          { properties: { title: 'Grid view' } }
+        ].concat(Object.values(sheetsInfo).map(info =>
+          Object.assign({ properties: { title: info.title } })
+        ))
+      },
+      fields: 'spreadsheetId,spreadsheetUrl',
+    });
+    const fileId = res.data.spreadsheetId;
+    console.warn(`- created new Google spreadsheet: ${res.data.spreadsheetUrl}`);
+
+    // Move sheet to shared folder
+    const drive = google.drive({
+      version: 'v3',
+      auth: authClient
+    });
+    if (driveId) {
+      res = await drive.files.get({
+        fileId,
+        fields: 'parents'
+      });
+      const rootFolderId = res.data.parents[0];
+      res = await drive.files.update({
+        fileId,
+        addParents: driveId,
+        removeParents: rootFolderId,
+        supportsAllDrives: true,
+        fields: 'parents'
+      });
+      if (res.data.parents[0] !== driveId) {
+        throw new Error('Could not move the spreadsheet to the provided shared drive. Check ID and permissions.');
+      }
+      console.warn(`- moved spreadsheet to shared drive: ${driveId}`);
+    }
+    else if (editorEmail) {
+      // Note: cannot transfer ownership because service account is not
+      // seen as being part of an organization by Google
+      res = await drive.permissions.create({
+        fileId,
+        resource: {
+          type: 'user',
+          role: 'editor',
+          emailAddress: editorEmail
+        }
+      });
+      console.warn(`- gave editor rights to: ${editorEmail}`);
+    }
+
+    return fileId;
+  }
+
+  // Information about the sheets within the spreadsheet
+  const sheetsInfo = {
+    sessions: {
+      titleMatch: /list/i,
+      title: 'List view'
+    },
+    meetings: {
+      titleMatch: /meetings/i,
+      title: 'Meetings',
+      specificTo: 'groups'
+    },
+    rooms: {
+      titleMatch: /rooms/i,
+      title: 'Rooms'
+    },
+    days: {
+      titleMatch: /days/i,
+      title: 'Days'
+    },
+    slots: {
+      titleMatch: /slots/i,
+      title: 'Slots'
+    }
+  };
+
+  /**
+   * Inner function to retrieve/create the appropriate sheets in the
+   * spreadsheet.
+   *
+   * The code needs the spreadsheet to contain the sheets listed in
+   * sheetsInfo, plus a first sheet with the grid view (the code does not
+   * enforce that though).
+   */
+  async function getOrCreateSheets(spreadsheetId) {
+    const res = await sheets.spreadsheets.get({ spreadsheetId });
+
+    function getSheet(data, name) {
+      return data?.find(sheet => sheet.properties.title.match(sheetsInfo[name].titleMatch));
+    }
+
+    const requests = Object.entries(sheetsInfo)
+      .filter(([name, desc]) => !desc.specificTo ||
+        project.metadata.type === desc.specificTo)
+      .filter(([name, desc]) => !getSheet(res.data.sheets, name))
+      .map(([name, desc]) => Object.assign({
+        addSheet: {
+          properties: {
+            title: sheetsInfo[name].title
+          }
+        }
+      }));
+    let updated;
+    if (requests.length > 0) {
+      updated = await sheets.spreadsheets.batchUpdate({
+        spreadsheetId,
+        resource: { requests },
+        includeSpreadsheetInResponse: true
+      });
+      console.warn(`- created missing sheets within the spreadsheet`);
+    }
+
+    for (const [name, desc] of Object.entries(sheetsInfo)) {
+      const sheet =
+        getSheet(res.data.sheets, name) ??
+        getSheet(updated?.data?.updatedSpreadsheet?.sheets, name);
+      if (sheet) {
+        desc.sheetId = sheet.properties.sheetId;
+        desc.title = sheet.properties.title;
+      }
+    }
+  }
+
+  /**
+   * Convert the provided value and optional cell format into the appropriate
+   * structure for the Google Sheets API
+   */
+  function makeCell(value, format) {
+    return {
+      userEnteredValue: typeof(value) === 'number' ?
+        Object.assign({ numberValue: value }) :
+        Object.assign({ stringValue: value }),
+      userEnteredFormat: Object.assign({
+        verticalAlignment: 'TOP'
+      }, format)
+    };
+  }
+
+  function getFreezeRequest(sheetId) {
+    return {
+      updateSheetProperties: {
+        fields: 'gridProperties.frozenRowCount',
+        properties: {
+          sheetId,
+          gridProperties: { frozenRowCount: 1 }
+        }
+      }
+    };
+  }
+
+  function getUpdateDimensionRequest(sheetId,
+      { dimension, startIndex, endIndex, pixelSize }) {
+    const range = endIndex ?
+      { sheetId, dimension, startIndex, endIndex } :
+      { sheetId, dimension, startIndex };
+    return {
+      updateDimensionProperties: {
+        range,
+        fields: 'pixelSize',
+        properties: { pixelSize }
+      }
+    };
+  }
+
+  function getColRangeValidationRequest(sheetId,
+      { startIndex, endIndex, range }) {
+    return {
+      setDataValidation: {
+        range: {
+          sheetId,
+          startRowIndex: 1,
+          startColumnIndex: startIndex,
+          endColumnIndex: endIndex
+        },
+        rule: {
+          condition: {
+            type: 'ONE_OF_RANGE',
+            values: [
+              { userEnteredValue: range }
+            ]
+          },
+          strict: true,
+          showCustomUi: true
+        }
+      }
+    }
+  }
+
+  /**
+   * Update the list of rooms
+   */
+  async function updateRooms() {
+    const sheetId = sheetsInfo.rooms.sheetId;
+    let res = await sheets.spreadsheets.values.clear({
+      spreadsheetId,
+      range: sheetsInfo.rooms.title
+    });
+
+    res = await sheets.spreadsheets.batchUpdate({
+      spreadsheetId,
+      resource: {
+        requests: [
+          // Fill out the headers' row
+          {
+            updateCells: {
+              start: { sheetId, rowIndex: 0, columnIndex: 0 },
+              fields: 'userEnteredValue',
+              rows: [
+                {
+                  values: [
+                    { userEnteredValue: { stringValue: 'ID' } },
+                    { userEnteredValue: { stringValue: 'Name' } },
+                    { userEnteredValue: { stringValue: 'Label' } },
+                    { userEnteredValue: { stringValue: 'Location' } },
+                    { userEnteredValue: { stringValue: 'Capacity' } }
+                  ]
+                }
+              ]
+            }
+          },
+
+          // Freeze the headers' row
+          getFreezeRequest(sheetId),
+
+          // Fill out the rest of the table (second row at index 1)
+          {
+            updateCells: {
+              start: { sheetId, rowIndex: 1, columnIndex: 0 },
+              fields: 'userEnteredValue,userEnteredFormat',
+              rows: project.rooms.map(room => {
+                const values = [
+                  makeCell(room.id),
+                  makeCell(room.name),
+                  makeCell(room.label),
+                  makeCell(room.location),
+                  makeCell(room.capacity)
+                ];
+                return { values };
+              })
+            }
+          },
+
+          // Shrink width of first column with issue number
+          getUpdateDimensionRequest(sheetId, {
+            dimension: 'COLUMNS',
+            startIndex: 0,
+            endIndex: 1,
+            pixelSize: 80
+          }),
+
+          // Enlarge width of second, third and fourth column
+          getUpdateDimensionRequest(sheetId, {
+            dimension: 'COLUMNS',
+            startIndex: 1,
+            endIndex: 4,
+            pixelSize: 150
+          }),
+
+          // Shrink width of fifth column
+          getUpdateDimensionRequest(sheetId, {
+            dimension: 'COLUMNS',
+            startIndex: 4,
+            endIndex: 5,
+            pixelSize: 60
+          })
+        ]
+      }
+    });
+  }
+
+  /**
+   * Update the list of days
+   */
+  async function updateDays() {
+    const sheetId = sheetsInfo.days.sheetId;
+    let res = await sheets.spreadsheets.values.clear({
+      spreadsheetId,
+      range: sheetsInfo.days.title
+    });
+
+    res = await sheets.spreadsheets.batchUpdate({
+      spreadsheetId,
+      resource: {
+        requests: [
+          // Fill out the headers' row
+          {
+            updateCells: {
+              start: { sheetId, rowIndex: 0, columnIndex: 0 },
+              fields: 'userEnteredValue',
+              rows: [
+                {
+                  values: [
+                    { userEnteredValue: { stringValue: 'ID' } },
+                    { userEnteredValue: { stringValue: 'Name' } },
+                    { userEnteredValue: { stringValue: 'Label' } },
+                    { userEnteredValue: { stringValue: 'Date' } }
+                  ]
+                }
+              ]
+            }
+          },
+
+          // Freeze the headers' row
+          getFreezeRequest(sheetId),
+
+          // Fill out the rest of the table (second row at index 1)
+          {
+            updateCells: {
+              start: { sheetId, rowIndex: 1, columnIndex: 0 },
+              fields: 'userEnteredValue,userEnteredFormat',
+              rows: project.days.map(day => {
+                const values = [
+                  makeCell(day.id),
+                  makeCell(day.name),
+                  makeCell(day.label),
+                  makeCell(day.date)
+                ];
+                return { values };
+              })
+            }
+          },
+
+          // Shrink width of first column with issue number
+          getUpdateDimensionRequest(sheetId, {
+            dimension: 'COLUMNS',
+            startIndex: 0,
+            endIndex: 1,
+            pixelSize: 80
+          }),
+
+          // Enlarge width of second and third column
+          getUpdateDimensionRequest(sheetId, {
+            dimension: 'COLUMNS',
+            startIndex: 1,
+            endIndex: 3,
+            pixelSize: 150
+          })
+        ]
+      }
+    });
+  }
+
+  /**
+   * Update the list of slots
+   */
+  async function updateSlots() {
+    const sheetId = sheetsInfo.slots.sheetId;
+    let res = await sheets.spreadsheets.values.clear({
+      spreadsheetId,
+      range: sheetsInfo.slots.title
+    });
+
+    res = await sheets.spreadsheets.batchUpdate({
+      spreadsheetId,
+      resource: {
+        requests: [
+          // Fill out the headers' row
+          {
+            updateCells: {
+              start: { sheetId, rowIndex: 0, columnIndex: 0 },
+              fields: 'userEnteredValue',
+              rows: [
+                {
+                  values: [
+                    { userEnteredValue: { stringValue: 'ID' } },
+                    { userEnteredValue: { stringValue: 'Name' } },
+                    { userEnteredValue: { stringValue: 'Start' } },
+                    { userEnteredValue: { stringValue: 'End' } },
+                    { userEnteredValue: { stringValue: 'Duration' } }
+                  ]
+                }
+              ]
+            }
+          },
+
+          // Freeze the headers' row
+          getFreezeRequest(sheetId),
+
+          // Fill out the rest of the table (second row at index 1)
+          {
+            updateCells: {
+              start: { sheetId, rowIndex: 1, columnIndex: 0 },
+              fields: 'userEnteredValue,userEnteredFormat',
+              rows: project.slots.map(slot => {
+                const values = [
+                  makeCell(slot.id),
+                  makeCell(slot.name),
+                  makeCell(slot.start),
+                  makeCell(slot.end),
+                  makeCell(slot.duration)
+                ];
+                return { values };
+              })
+            }
+          },
+
+          // Shrink width of first column with issue number
+          getUpdateDimensionRequest(sheetId, {
+            dimension: 'COLUMNS',
+            startIndex: 0,
+            endIndex: 1,
+            pixelSize: 80
+          }),
+
+          // Shrink width of fourth to sixth column
+          getUpdateDimensionRequest(sheetId, {
+            dimension: 'COLUMNS',
+            startIndex: 3,
+            endIndex: 6,
+            pixelSize: 60
+          })
+        ]
+      }
+    });
+  }
+
+  /**
+   * Update the list of sessions
+   */
+  async function updateSessions() {
+    const sheetId = sheetsInfo.sessions.sheetId;
+    let res = await sheets.spreadsheets.values.clear({
+      spreadsheetId,
+      range: sheetsInfo.sessions.title
+    });
+
+    // Prepare lists of unique values to set validation constraints
+    const authors = [...new Set(project.sessions.map(s => s.author.login))];
+
+    // Fill out the list view
+    res = await sheets.spreadsheets.batchUpdate({
+      spreadsheetId,
+      resource: {
+        requests: [
+          // Reset data validation constraints
+          {
+            setDataValidation: {
+              range: { sheetId }
+            }
+          },
+
+          // Fill out the headers' row
+          {
+            updateCells: {
+              start: { sheetId, rowIndex: 0, columnIndex: 0 },
+              fields: 'userEnteredValue',
+              rows: [
+                {
+                  values: [
+                    { userEnteredValue: { stringValue: 'Number' } },
+                    { userEnteredValue: { stringValue: 'Title' } },
+                    { userEnteredValue: { stringValue: 'Author' } },
+                    { userEnteredValue: { stringValue: 'Body' } },
+                    { userEnteredValue: { stringValue: 'Labels' } },
+                    { userEnteredValue: { stringValue: 'Room' } },
+                    { userEnteredValue: { stringValue: 'Day' } },
+                    { userEnteredValue: { stringValue: 'Slot' } },
+                    { userEnteredValue: { stringValue: 'Meeting' } },
+                    { userEnteredValue: { stringValue: 'Error' } },
+                    { userEnteredValue: { stringValue: 'Warning' } },
+                    { userEnteredValue: { stringValue: 'Check' } },
+                    { userEnteredValue: { stringValue: 'Note' } },
+                    { userEnteredValue: { stringValue: 'Registrants' } }
+                  ]
+                }
+              ]
+            }
+          },
+
+          // Freeze the headers' row
+          getFreezeRequest(sheetId),
+
+          // Fill out the rest of the table (second row at index 1)
+          {
+            updateCells: {
+              start: { sheetId, rowIndex: 1, columnIndex: 0 },
+              fields: 'userEnteredValue,userEnteredFormat',
+              rows: project.sessions.map(session => {
+                const values = [
+                  makeCell(session.number, {
+                    textFormat: {
+                      link: {
+                        uri: `https://github.com/${session.repository}/issues/${session.number}`
+                      }
+                    },
+                    hyperlinkDisplayType: 'LINKED'
+                  }),
+                  makeCell(session.title, { wrapStrategy: 'WRAP' }),
+                  makeCell(session.author.login),
+                  makeCell(session.body, { wrapStrategy: 'WRAP' })
+                ];
+                const labels = session.labels.filter(label => label !== 'session');
+                values.push(makeCell(labels.join(',') ?? ''));
+                if (session.room) {
+                  const room = project.rooms.find(v => v.name === session.room);
+                  values.push(makeCell(room.label));
+                }
+                else {
+                  values.push(makeCell(''));
+                }
+                if (session.day) {
+                  const day = project.days.find(v => v.name === session.day);
+                  values.push(makeCell(day.label));
+                }
+                else {
+                  values.push(makeCell(''));
+                }
+                if (session.slot) {
+                  const slot = project.slots.find(v => v.name === session.slot);
+                  values.push(makeCell(slot.name));
+                }
+                else {
+                  values.push(makeCell(''));
+                }
+                values.push(makeCell(
+                  (session.meeting ?? '').split(/\s*;\s*/).join('\n')));
+                for (const field of ['error', 'warning', 'check', 'note']) {
+                  values.push(makeCell(session.validation[field] ?? ''));
+                }
+                values.push(makeCell(session.registrants ?? ''));
+                return { values };
+              })
+            }
+          },
+
+          // Set data validation constraint on authors (third column at index 2)
+          {
+            setDataValidation: {
+              range: {
+                sheetId,
+                startRowIndex: 1,
+                startColumnIndex: 2,
+                endColumnIndex: 3
+              },
+              rule: {
+                condition: {
+                  type: 'ONE_OF_LIST',
+                  values: authors.map(author =>
+                    Object.assign({ userEnteredValue: author }))
+                },
+                strict: true,
+                showCustomUi: true
+              }
+            }
+          },
+
+          // Set data validation constraint on rooms (sixth column at index 5)
+          getColRangeValidationRequest(sheetId, {
+            startIndex: 5,
+            endIndex: 6,
+            range: `='${sheetsInfo.rooms.title}'!C2:C`
+          }),
+
+          // Set data validation constraint on days (seventh column at index 6)
+          getColRangeValidationRequest(sheetId, {
+            startIndex: 6,
+            endIndex: 7,
+            range: `='${sheetsInfo.days.title}'!C2:C`
+          }),
+
+          // Set data validation constraint on slots (eighth column at index 7)
+          getColRangeValidationRequest(sheetId, {
+            startIndex: 7,
+            endIndex: 8,
+            range: `='${sheetsInfo.slots.title}'!B2:B`
+          }),
+
+          // Set height of rows
+          getUpdateDimensionRequest(sheetId, {
+            dimension: 'ROWS',
+            startIndex: 1,
+            pixelSize: 60
+          }),
+
+          // Shrink width of first column with issue number
+          getUpdateDimensionRequest(sheetId, {
+            dimension: 'COLUMNS',
+            startIndex: 0,
+            endIndex: 1,
+            pixelSize: 60
+          }),
+          
+          // Enlarge title column
+          getUpdateDimensionRequest(sheetId, {
+            dimension: 'COLUMNS',
+            startIndex: 1,
+            endIndex: 2,
+            pixelSize: 300
+          }),
+          
+          // Enlarge issue body column
+          getUpdateDimensionRequest(sheetId, {
+            dimension: 'COLUMNS',
+            startIndex: 3,
+            endIndex: 4,
+            pixelSize: 300
+          }),
+          
+          // Enlarge room and day columns
+          getUpdateDimensionRequest(sheetId, {
+            dimension: 'COLUMNS',
+            startIndex: 5,
+            endIndex: 7,
+            pixelSize: 150
+          })
+        ]
+      }
+    });
+  }
+
+  /**
+   * The list of meetings provides an expanded view of the "Meeting" column
+   * in the list of sessions
+   */
+  async function updateMeetings() {
+    if (project.metadata.type !== 'groups') {
+      return;
+    }
+    const sheetId = sheetsInfo.meetings.sheetId;
+
+    let res = await sheets.spreadsheets.values.clear({
+      spreadsheetId,
+      range: sheetsInfo.meetings.title
+    });
+
+    res = await sheets.spreadsheets.batchUpdate({
+      spreadsheetId,
+      resource: {
+        requests: [
+          // Reset data validation constraints
+          {
+            setDataValidation: {
+              range: { sheetId }
+            }
+          },
+
+          // Fill out the headers' row
+          {
+            updateCells: {
+              start: { sheetId, rowIndex: 0, columnIndex: 0 },
+              fields: 'userEnteredValue',
+              rows: [
+                {
+                  values: [
+                    { userEnteredValue: { stringValue: 'Number' } },
+                    { userEnteredValue: { stringValue: 'Day' } },
+                    { userEnteredValue: { stringValue: 'Slot' } },
+                    { userEnteredValue: { stringValue: 'Room' } }
+                  ]
+                }
+              ]
+            }
+          },
+
+          // Freeze the headers' row
+          getFreezeRequest(sheetId),
+
+          // Fill out the rest of the table (second row at index 1)
+          {
+            updateCells: {
+              start: { sheetId, rowIndex: 1, columnIndex: 0 },
+              fields: 'userEnteredValue,userEnteredFormat',
+              rows: project.sessions
+                .map(session =>
+                  parseSessionMeetings(session, project).map(meeting =>
+                    Object.assign({ number: session.number }, meeting)))
+                .flat()
+                .map(meeting => {
+                  const values = [
+                    makeCell(meeting.number)
+                  ];
+                  if (meeting.day) {
+                    const day = project.days.find(v => v.name === meeting.day);
+                    values.push(makeCell(day.label));
+                  }
+                  else {
+                    values.push(makeCell(''));
+                  }
+                  if (meeting.slot) {
+                    const slot = project.slots.find(v => v.name === meeting.slot);
+                    values.push(makeCell(slot.name));
+                  }
+                  else {
+                    values.push(makeCell(''));
+                  }
+                  if (meeting.room) {
+                    const room = project.rooms.find(v => v.name === meeting.room);
+                    values.push(makeCell(room.label));
+                  }
+                  else {
+                    values.push(makeCell(''));
+                  }
+                  return { values };
+                })
+            }
+          }
+        ]
+      }
+    });
+  }
+
+  // Create the spreadsheet if needed
+  if (!spreadsheetId) {
+    spreadsheetId = await createSpreadsheet();
+  }
+  await getOrCreateSheets(spreadsheetId);
+
+  // Fill out the spreadsheet
+  await updateRooms();
+  await updateDays();
+  await updateSlots();
+  await updateSessions();
+  await updateMeetings();
+
+  /*res = await sheets.spreadsheets.get({
+    spreadsheetId,
+    includeGridData: true
+  });
+  console.log(JSON.stringify(res.data, null, 2));*/
+}


### PR DESCRIPTION
The new `sync-sheet` CLI command copies the event's data (from the GitHub repo and from the underlying GitHub project) to a Google spreadsheet. It creates the spreadsheet as needed. The goal is to be able to generate a grid view automatically.