### PR TITLE
Make clearer that import sessions does not import schedule info

### DIFF
--- a/tools/appscript/import-sessions.mjs
+++ b/tools/appscript/import-sessions.mjs
@@ -15,6 +15,12 @@ export default async function () {
           <b>${githubProject.sessions.length}</b>
           sessions retrieved from GitHub.
         </p>
+        <p><strong>Note:</strong> The import did not
+	  affect existing schedule information (day, slot room)
+	  in the spreadsheet. In general, you should not have
+	  to import schedule information from GitHub, but if you do,
+	  that option is available in the "Advanced" menu.
+        </p>
       `)
       .setWidth(300)
       .setHeight(400);


### PR DESCRIPTION
In HTML rendered after importing session information, make clearer that schedule information (room, stay, slot) are not updated in the spreadsheed, but that when it's necessary to do that, there's an option in the advanced menu.