### PR TITLE
Get rid of `day` for sessions throughout

### DIFF
--- a/test/check-meeting-parsing.mjs
+++ b/test/check-meeting-parsing.mjs
@@ -162,8 +162,7 @@ describe('The meeting field parser', function () {
     const project = await loadProject();
     const session = {
       room: 'Room 1',
-      day: '2042-02-10',
-      meeting: '9:00<8:30>; 11:00; 14:00 - 16:00<15:30>'
+      meeting: '2042-02-10, 9:00<8:30>; 2042-02-10, 11:00; 2042-02-10, 14:00 - 16:00<15:30>'
     };
     const merged = groupSessionMeetings(session, project);
     assert.deepStrictEqual(merged, [

--- a/test/check-track-schedule-with-constraints.mjs
+++ b/test/check-track-schedule-with-constraints.mjs
@@ -20,7 +20,7 @@ describe('When given track sessions with constraints, the scheduler', function (
     // The seed actually shuffles the two sessions in the order we need:
     // 1 first, then 2.
     suggestSchedule(project, { seed: 12345 });
-    assert.deepStrictEqual(sessionWithoutConflicts.slot, '10:00');
+    assert.deepStrictEqual(sessionWithoutConflicts.slot, '2042-04-05 10:00');
   });
 
   it('priorities the session with time slot constraints even when initial order suggests the opposite', async function () {
@@ -31,6 +31,6 @@ describe('When given track sessions with constraints, the scheduler', function (
     // The seed actually shuffles the two sessions in the order we need:
     // 2 first, then 1.
     suggestSchedule(project, { seed: 1234 });
-    assert.deepStrictEqual(sessionWithoutConflicts.slot, '10:00');
+    assert.deepStrictEqual(sessionWithoutConflicts.slot, '2042-04-05 10:00');
   });
 });

--- a/test/data/breakouts-day-2024-reduce.mjs
+++ b/test/data/breakouts-day-2024-reduce.mjs
@@ -29,99 +29,88 @@ export default {
       "body": "### Session description\n\nThe process of incubation, and some of its parameters, are not currently well-defined at W3C.  I'd like to gather perspectives to further the work on Incubation in the AB (https://github.com/w3c/AB-memberonly/blob/master/documents/Incubation.md).\n\nSome provoking questions to explore:\n- How should incubation work?\n- At what stage of \"doneness\" should work move from an incubation venue to a working group?\n- How should an incubation group be communicating their work to a broader venue to ease acceptance as a WG deliverable?\n- What expectation of incubation should there be before work is accepted into a WG, or into its charter?\n- What best practices should we define for referring to incubations?\n\n### Session goal\n\nGather input and perspectives to further the AB work on improving incubation process\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n_No response_\n\n### IRC channel (Optional)\n\n#incubation\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n#19, #20, #22\n\n### Instructions for meeting planners (Optional)\n\nThis may be related to #22.\n\n### Agenda (link or inline) (Optional)\n\n_No response_\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/637c8829-f322-4799-8787-2fefec8ce327/)\n\n### Meeting materials (Optional)\n\n- [Minutes](https://www.w3.org/2024/03/12-incubation-minutes.html)",
       "number": 24,
       "title": "Incubation: the on ramp to new work",
-      "day": "2024-03-12",
       "room": "Kora",
-      "slot": "22:00"
+      "slot": "2024-03-12 22:00"
     },
     {
       "author": "tidoust",
       "body": "### Session description\n\nHow do web developers talk about web features? What names do they use? How do these features map to specifications, fine-grained API functions and tests? What does a developer view tell us about the interoperability of the web platform?\n\nThe [`web-features` project](https://github.com/web-platform-dx/web-features), [envisioned in 2022](https://www.w3.org/2022/09/TPAC/breakouts.html#webdx) and [launched in 2023](https://www.w3.org/2023/09/TPAC/demos/web-features.html), explores the set of interoperable features of the web platform by:\n\n- Creating feature definitions, which identify and describe capabilities of web browsers.\n- Generating [Baseline](https://github.com/web-platform-dx/web-features/blob/main/docs/baseline.md) support data, which summarizes the availability of web features across key browsers and releases.\n- Publishing the `web-features` npm package, which bundles feature identifiers with Baseline statuses.\n\nDeveloped by the WebDX Community Group and contributors, web-features data leverages compatibility data from the browser-compat-data project, is already [integrated in MDN](https://developer.mozilla.org/en-US/blog/baseline-evolution-on-mdn/), [Can I Use](https://caniuse.com/css-nesting), [Web Platform Tests](https://github.com/web-platform-tests/wpt.fyi/blob/main/api/query/README.md#feature), and is starting to reach additional authors of JavaScript libraries and dashboards.\n\nLooking forward, feature identifiers at the \"right\" level make it possible to tag signals from the web community in surveys, browser standard positions, bug trackers, polyfills and usage counters. It also makes it easier to combine these signals with other projects that generate data out of specifications such as [`browser-specs`](https://github.com/w3c/browser-specs/) and [webref](https://github.com/w3c/webref).\n\nFeatures are also used in standardization groups, informally to organize discussions, but also formally to address transition requirements set forth by the W3C Process Document for advancing specifications on the Recommendation track. Within the Process, [new features](https://www.w3.org/2023/Process-20231103/#class-4) are defined as substantive changes that add new functionality, and used to assess [implementation experience](https://www.w3.org/2023/Process-20231103/#implementation-experience), document functionality that is considered [at risk](https://www.w3.org/2023/Process-20231103/#at-risk), and scope changes that may be incorporated in a specification depending on its maturity stage. This raises questions on the intersection between web-features and W3C’s standardization process, including:\n\n- Can web-features provide useful information to working groups?\n- Can it also inform the standardization process, e.g., to detect the need to transition a feature implemented by more than one browser out of incubation?\n- What additional data or tooling would make web-features a powerful tool for standards bodies?\n- How would **you** like to see web-features data presented in standards work?\n\n### Session goal\n\nShare updates on the web-features project, its use to inform the standardization process, and additional data, tooling and visualizations to make web-features a powerful tool for standards bodies.\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n@captainbrosset, @atopal\n\n### IRC channel (Optional)\n\n#web-features\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n_No response_\n\n### Instructions for meeting planners (Optional)\n\n_No response_\n\n### Agenda (link or inline) (Optional)\n\n- Presentation (20mn - see [slides](https://docs.google.com/presentation/d/e/2PACX-1vT5PiEfUCia_p-hIKu-LxQ90qwQks42FtsXTxI4wATYuG1OWEQlCnGcP7R_gENVnGUa82ZTGkQXQgRQ/pub))\n  - Web developers and web features\n  - Web features and standardization\n  - First stab at gathering signals to inform standardization process\n    - Late incubations\n    - Late Working Drafts\n    - Not-so-well supported Recommendations\n- Discussion (30mn)\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/9e7690a7-cd77-4192-ab60-337243f9b70a/)\n\n### Meeting materials (Optional)\n\n- [Minutes](https://www.w3.org/2024/03/12-web-features-minutes.html)",
       "number": 22,
       "title": "Web features, Baseline status, and standardization signals",
-      "day": "2024-03-12",
       "room": "Koto",
-      "slot": "14:00"
+      "slot": "2024-03-12 14:00"
     },
     {
       "author": "rdfguy",
       "body": "### Session description\n\nThis session will have a short presentation about the current state of the work the RDF-Star WG is undertaking, followed by Q&A and discussion.\n\n### Session goal\n\nInform interested parties about RDF-Star (aka RDF 1.2)\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n@ktk\n\n### IRC channel (Optional)\n\n#rdf-star\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n_No response_\n\n### Instructions for meeting planners (Optional)\n\nWe would prefer a in the first time slot (1-3 pm UTC).\n\n### Agenda (link or inline) (Optional)\n\n_No response_\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/0fc23324-8bf1-47b8-b0cf-1f0f31befb09/)\n\n### Meeting materials (Optional)\n\n* Minutes: TBD",
       "number": 21,
       "title": "RDF-Star and RDF 1.2",
-      "day": "2024-03-12",
       "room": "Erhu",
-      "slot": "13:00"
+      "slot": "2024-03-12 13:00"
     },
     {
       "author": "bkardell",
       "body": "### Session description\n\nThe Web has billions of users, and most users have many, many dependencies on the web. The ecosystem around the web, which includes things like web engines, is both incredibly complex and fundamentally critical.\n\nBut the model that has driven, funded, and sustained this ecosystem isn’t ideal. There is no guarantee that it will be sustainable over the long term, but beyond that, it already falls quite short of funding everything that needs to be done. There is just too much. Many things go long ignored simply because prioritization is hard, and funds are ultimately limited. This includes everything from new features in popular languages like CSS and JS up to entire languages like MathML and SVG, which have largely been the work of (often unpaid) individual contributors.\n\nIn this session, we intend to have a community discussion of alternative models for funding the web ecosystem, from collective funding pools to changes in open source project policies to changes in tax law, and beyond.\n\n### Session goal\n\nTo help further discussions toward better solutions\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n@darobin, @meyerweb\n\n### IRC channel (Optional)\n\n#ecosystem-funding\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n#17, #16, #12\n\n### Instructions for meeting planners (Optional)\n\nThose conflicts are \"nice to avoid\" but not critical.\n\n### Agenda (link or inline) (Optional)\n\n_No response_\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/413b7511-d5e7-491a-9666-0535c844d52c/)\n\n### Meeting materials (Optional)\n\n- [Minutes](https://www.w3.org/2024/03/12-ecosystem-funding-minutes.html)",
       "number": 20,
       "title": "How We Fund the Web Ecosystem",
-      "day": "2024-03-12",
       "room": "Koto",
-      "slot": "21:00"
+      "slot": "2024-03-12 21:00"
     },
     {
       "author": "rupakc",
       "body": "### Session description\n\nThe proliferation of Generative AI has disrupted many industries and is poised to change significant aspects of our society. Without guardrails, we have often seen conversational AI agents overfitting to the bias in the training data which negatively impacts users. At eyeo, we build machine learning solutions on a web-scale, and in order to ensure our models are fair and sustainable, we have taken several concrete steps to transform the input data and calibrate the model evaluation to reflect real-world scenarios. We believe it’s high time to start a discussion around having a formal framework which outlines the ethical considerations for the use of Generative AI and AI in general. During the session, we will explore the challenges and opportunities that lie ahead from a technical and social perspective.\n\nThis builds on our session on [Ethical AI during TPAC 2023](https://github.com/w3c/tpac2023-breakouts/issues/72), with a focus on Generative AI.\n\n### Session goal\n\nBrainstorm ideas on the ethics of these new and upcoming technologies (Generative AI) and discuss the implications of adopting these on a large scale from a social, economic and technical perspective.\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n@humeranoor\n\n### IRC channel (Optional)\n\n#ethical-ai\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n_No response_\n\n### Instructions for meeting planners (Optional)\n\n_No response_\n\n### Agenda (link or inline) (Optional)\n\n1. Rise of Generative AI \n2. Role of the World Wide Web in the adoption of these technologies\n3. Steps we take at eyeo to de-bias our web-scale Machine Learning models\n4. Ethical Implications of the use of these technologies\n5. The future of setting ethical standards for Generative AI\n\n#### Additional Information \n\nDuring the course of the session, we will be making use of this **[Miro Board](https://miro.com/app/board/uXjVNkFEEw8=/)**, please make sure you are able to view this. The board is password-protected at the moment. At the beginning of the session, we will share the password with all the participants. \n\nWe have also planned a short presentation at the start of the session. You can find the **[slide deck here](https://docs.google.com/presentation/d/1TdZvKi8AIsDUlWYeg9cHqRHA-tDiCuhe6m5B61o5sxs/edit#slide=id.g25c658642cb_2_1093)**\n\nFinally, while preparing for the session we made notes and organized relevant details pertaining to the existing literature on Ethics for AI and Generative AI. In case you are interested please have a look at this **[Google Doc](https://docs.google.com/document/d/1jv7_4JD0ynIV_bFdf3hqm_sg74twHbflOOYWafnQFwg/edit)**\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/27e8a549-c121-4c70-a6f9-ac987528c27f/)\n\n### Meeting materials (Optional)\n\n* Minutes: TBD",
       "number": 19,
       "title": "Ethical Implications of Generative AI",
-      "day": "2024-03-12",
       "room": "Lyre",
-      "slot": "21:00"
+      "slot": "2024-03-12 21:00"
     },
     {
       "author": "egekorkan",
       "body": "### Session description\n\nThe Web of Things Working Group is working on defining a registry mechanism where the wide WoT community, including other organizations like other SDOs, can contribute WoT bindings of existing protocols and media types. The WG has analyzed approaches within (official and not official ones) and outside of W3C and in this breakout we want to share our findings with the wide W3C, get inputs, and collaborate on building knowledge on how to manage registries for each technical report.\n\n[Slides](https://docs.google.com/presentation/d/1zWnl7yWMKPjKgtjogZGDe-8xf4KTK3KakhPY0_uhsB4/edit?usp=sharing)\n\n### Session goal\n\nDiscussion and Collection of Opinion\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n@jkRhb\n\n### IRC channel (Optional)\n\n#registries\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n_No response_\n\n### Instructions for meeting planners (Optional)\n\nIf possible, we prefer a slot between 11 and 15 CET.\n\n### Agenda (link or inline) (Optional)\n\n- Share the registry analysis of the WoT WG with everyone and get feedback\n- Discussion on managing registries in W3C\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/7c1b6bcd-9ee1-4570-ba4d-9ccad717e78f/)\n\n### Meeting materials (Optional)\n\n- [Minutes](https://www.w3.org/2024/03/12-registries-minutes.html)",
       "number": 18,
       "title": "Registries for W3C Specifications",
-      "day": "2024-03-12",
       "room": "Kora",
-      "slot": "13:00"
+      "slot": "2024-03-12 13:00"
     },
     {
       "author": "diekus",
       "body": "### Session description\r\n\r\nThis breakout session is to talk about ideas we have regarding enabling installation of web apps and web content through the platform natively. This is a new proposal that aims at democratizing application distribution. \r\n\r\nThe goals for the session are to describe and generate discussion about the challenges functionality like this might have. The session is open to the public.\r\n\r\n### Session goal\r\n\r\nDescribe and generate discussion about the challenges functionality like this might have.\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n@amandabaker\r\n\r\n### IRC channel (Optional)\r\n\r\n#installing-web-apps-breakout-2024\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n_No response_\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\n_No response_\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n_No response_\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/dbd11d7e-d721-49ce-99d2-72b91e0d7030/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n- [Minutes](https://www.w3.org/2024/03/12-installing-web-apps-breakout-2024-minutes.html)",
       "number": 17,
       "title": "Installing web apps as a new platform feature",
-      "day": "2024-03-12",
       "room": "Gamba",
-      "slot": "22:00"
+      "slot": "2024-03-12 22:00"
     },
     {
       "author": "torgo",
       "body": "### Session description\r\n\r\nThe Technical Architecture Group Privacy [task force](https://github.com/w3ctag/privacy-principles), together with participation from Privacy Interest Group, has been working on a set of [privacy principles](https://www.w3.org/TR/ethical-web-principles/) for the web. This is intended to be used by browser developers, authors of web specifications, reviewers of web specifications (such as the TAG and other groups participating in horizontal review), and web developers themselves. Now this document is going through wide review in advance of publication as a W3C Statement. We will present the principles and then have an open discussion.\r\n\r\n### Session goal\r\n\r\nIncrease awareness of the Privacy Principles, answer questions, gather feedback on how to improve the draft.\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n@darobin, @jyasskin\r\n\r\n### IRC channel (Optional)\r\n\r\n#privacy-principles\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n#12\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\nTo avoid in addition to #12: Other privacy-related sessions or sessions involving TAG members.\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n* Brief [presentation](https://github.com/w3ctag/privacy-principles/blob/main/meetings/2024-03-breakouts/slides.html) of an overview of the principles\r\n* Guided discussion\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/9330e02e-2f20-4cb0-9fe3-22fd9dcdb629/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n- [Minutes](https://github.com/w3ctag/privacy-principles/blob/main/meetings/2024-03-breakouts/minutes.md)",
       "number": 16,
       "title": "Privacy Principles for the Web",
-      "day": "2024-03-12",
       "room": "Gamba",
-      "slot": "14:00"
+      "slot": "2024-03-12 14:00"
     },
     {
       "author": "egekorkan",
       "body": "### Session description\n\nAs a follow-up of [Schemata Breakout of TPAC23](https://github.com/w3c/tpac2023-breakouts/issues/8), we want to further discuss ways to manage ontologies, schemas, and similar documents together. In the scope of the Thing Description Task Force at the Web of Things WG, we have analyzed some approaches such as LinkML, TreeLDR, Eclipse Semantic Modelling Framework, that we want to present. We have also identified that the topic of versioning, packaging, and serving these resources is a pressing topic that is not specific to the WoT. After these, we want to discuss on how to better continue the discussions in this topic area within the W3C.\n\n[Slides](https://docs.google.com/presentation/d/193OFcFaxD0GqrRuOggwZe5eorgL1C1Epe2cAYN3JEkk/edit?usp=sharing)\n\n### Session goal\n\nDiscussion and Collection of Opinion\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n_No response_\n\n### IRC channel (Optional)\n\n#schemata-discussion\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n#18\n\n### Instructions for meeting planners (Optional)\n\n_No response_\n\n### Agenda (link or inline) (Optional)\n\n- Recap of the TPAC2023 Breakout\n- Results of [the analysis](https://github.com/w3c/wot-thing-description/blob/egekorkan-patch-3/toolchain/tool-analysis.md) of tools at the WoT WG\n- Versioning, packaging and serving resources\n- Continuation of the work\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/fb7b6d9f-fc2f-456f-9fff-3a516f3ec7ab/)\n\n### Meeting materials (Optional)\n\n- [Minutes](https://www.w3.org/2024/03/12-schemata-discussion-minutes.html)",
       "number": 15,
       "title": "Schemata Discussion - Follow up from TPAC23",
-      "day": "2024-03-12",
       "room": "Kora",
-      "slot": "14:00"
+      "slot": "2024-03-12 14:00"
     },
     {
       "author": "wbamberg",
       "body": "### Session description\r\n\r\nAt the [Secure the Web Forward](https://www.w3.org/2023/03/secure-the-web-forward/report.html) workshop in 2023, writers from Open Web Docs led a [discussion about the state of web security docs on MDN](https://www.w3.org/2023/03/secure-the-web-forward/report.html#documentation). One outcome from this was that OWD would draft an outline for some improved security documentation for MDN, which would be written in 2024.\r\n\r\nWe've now written up a draft outline and it's had some internal review: https://docs.google.com/document/d/1p1GtjmTd1uQrO2PRb_uUflAfQpEsfs7hBaopYeuoPMM/edit, and we're ready for some more extensive review of the outline before we start writing docs.\r\n\r\nWe're very keen on finding security experts to collaborate with us on this project, both in these early stages as we scope the project, and for detailed technical review of documents as we write them.\r\n\r\nIn this session, we'll present the draft outline, discuss any feedback, and next steps, which we hope will be making a start on the documentation!\r\n\r\n### Session goal\r\n\r\nReview MDN web security docs outline proposal\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n_No response_\r\n\r\n### IRC channel (Optional)\r\n\r\n#mdn-security\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n#20, #22\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\nI'd prefer this to be scheduled not earlier than 4pm UTC.\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n- Present security docs outline\r\n- Discuss any questions that come up\r\n- Propose next steps for the project\r\n- Slides: https://wbamberg.github.io/web-security-w3c-breakouts-march-2024/\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/28cae5e2-8941-4d36-83fa-5a94f54a7d9a/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n- [Minutes](https://www.w3.org/2024/03/12-mdn-security-minutes.html)\r\n- [Recording](https://www.w3.org/2024/03/breakouts-day-2024/recordings/recording-14.html)",
       "number": 14,
       "title": "Web security docs for MDN",
-      "day": "2024-03-12",
       "room": "Koto",
-      "slot": "22:00"
+      "slot": "2024-03-12 22:00"
     },
     {
       "author": "wareid",
       "body": "### Session description\r\n\r\nFacilitating meetings in technical spaces is an important skill, and there are not many resources on how to do it for people new to the practice or new to W3C. Based on the [meeting facilitation training](https://www.w3.org/events/happenings/2023/meeting-facilitation-training/) developed by the Positive Work Environments CG at W3C, this session will provide a condensed version of the training covering how to effectively run meetings in a W3C context, how to handle code of conduct matters, and how to handle conflict.\r\n\r\n### Session goal\r\n\r\nProvide meeting facilitators with information and guidance on running better meetings.\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n_No response_\r\n\r\n### IRC channel (Optional)\r\n\r\n#running-meetings\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n_No response_\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\n_No response_\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n* Effective meeting facilitation\r\n  * Setting the stage \r\n  * Tooling\r\n  * Fostering discussion \r\n* Introducing the code of conduct\r\n  * Role of the facilitator\r\n* Handling difficult situations\r\n  * De-escalation\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/fa279254-9abd-42c3-af11-5bb50851154b/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n- [Minutes](https://www.w3.org/2024/03/12-running-meetings-minutes.html)\r\n- [Recording](https://www.w3.org/2024/03/breakouts-day-2024/recordings/recording-13.html)",
       "number": 13,
       "title": "Running Better Meetings - How to Facilitate at W3C",
-      "day": "2024-03-12",
       "room": "Gamba",
-      "slot": "13:00"
+      "slot": "2024-03-12 13:00"
     },
     {
       "author": "martinthomson",
@@ -129,27 +118,24 @@ export default {
       "tracks": ["identity"],
       "number": 12,
       "title": "Building Consensus on the Role of Real World Identities on the Web",
-      "day": "2024-03-12",
       "room": "Ukulele",
-      "slot": "13:00"
+      "slot": "2024-03-12 13:00"
     },
     {
       "author": "matatk",
       "body": "### Session description\r\n\r\nThe move to Github for tracking our work - including actions, and various horizontal review tasks - has been a boon for productivity, and transparency. However, it can be hard to keep up to date with all the work that's going on, especially for TF facilitators, WG chairs, people who take part in horizontal review activities, and people who find the command line more accessible.\r\n\r\nWith a hat tipped to Tracker, our long-time action management tool, APA WG has been exploring the possibilities for presenting the rich and robust GitHub process on the command line. But this isn't just for APA WG; it's intended to be of use to TF facilitators and WG chairs across W3C.\r\n\r\n### Session goal\r\n\r\nDemonstrate our command-line work tracking tool, and seek feedback from potential users\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n_No response_\r\n\r\n### IRC channel (Optional)\r\n\r\n#nu-tracker\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n#10\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\nMeeting must _start_ between 0700 and 2100 UTC.\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n* Use cases for a new interface to the GitHub process\r\n* Demo of Nu Tracker\r\n* Roadmap\r\n* Questions and feedback\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/7f29f666-3931-49f8-a44c-93bd9807ab2d/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n- [Minutes](https://www.w3.org/2024/03/breakout-nu-tracker-minutes.txt)",
       "number": 11,
       "title": "Nu Tracker: Helping you manage actions and horizontal review tasks from the command line",
-      "day": "2024-03-12",
       "room": "Lyre",
-      "slot": "13:00"
+      "slot": "2024-03-12 13:00"
     },
     {
       "author": "matatk",
       "body": "### Session description\r\n\r\nNavigation around sites can be complex, presenting barriers for people who struggle to understand the visual layout, or terminology that a site uses. However, there are several key sections or pages that can be found across many sites. The WAI-Adapt Task Force is exploring an approach (pending review) to address these barriers.\r\n\r\nThis session introduces the problem, shows how we envisage the solution working, from the user's perspective - via a demo of an interactive browser extension - and describes our proposed approach, in order to answer your questions, and gather informal feedback before we apply for horizontal and wide review from the community.\r\n\r\n### Session goal\r\n\r\nRaise awareness of the challenges of site navigation, and a potential simple, semantic, standardized solution\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n_No response_\r\n\r\n### IRC channel (Optional)\r\n\r\n#adapt\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n#11\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\nMeeting must _start_ between 0700 and 2100 UTC.\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n* Site navigation barriers\r\n* What support could look like in the browser (demo)\r\n* WAI-Adapt's proposed solution\r\n* Next steps (i.e. seeking review)\r\n* Discussion\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/0ac4bc8d-6dc8-48db-a822-7525eb9cd093/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n- [Minutes](https://www.w3.org/2024/03/12-adapt-minutes.html)\r\n- [Recording](https://www.w3.org/2024/03/breakouts-day-2024/recordings/recording-10.html)",
       "number": 10,
       "title": "Exploring making site navigation more accessible, with \"well-known destinations\"",
-      "day": "2024-03-12",
       "room": "Lyre",
-      "slot": "14:00"
+      "slot": "2024-03-12 14:00"
     },
     {
       "author": "npm1",
@@ -157,9 +143,8 @@ export default {
       "tracks": ["identity"],
       "number": 9,
       "title": "FedCM multiple IDP support",
-      "day": "2024-03-12",
       "room": "Ukulele",
-      "slot": "21:00"
+      "slot": "2024-03-12 21:00"
     },
     {
       "author": "domfarolino",
@@ -167,18 +152,16 @@ export default {
       "tracks": ["identity"],
       "number": 7,
       "title": "FedCM request settings & CORS",
-      "day": "2024-03-12",
       "room": "Ukulele",
-      "slot": "14:00"
+      "slot": "2024-03-12 14:00"
     },
     {
       "author": "JAlanBird-DO",
       "body": "### Session description\r\n\r\nThe mission of the Real Estate Community Group is to provide a forum for real estate-related technical discussions to track progress of technology features on the Web within W3C groups, educate on the use of Web technologies by external organizations, and to identify use cases and requirements that existing and/or new specifications need to meet to deliver a more inclusive, robust experiences to the Real Estate ecosystem.  This session will discuss the group, answer questions and briefly demonstrate the DO AudioTours technology built by Direct Offer.\r\n\r\nAdditional session chair: Amy Chorew.\r\n\r\n### Session goal\r\n\r\nGet support for the group\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n_No response_\r\n\r\n### IRC channel (Optional)\r\n\r\n#3Realestate\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n_No response_\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\n_No response_\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n* Introductions \r\n* Why we're creating the CG\r\n* Who are the potential actors in the group\r\n* What it does for the real estate industry\r\n* demo of DO AudioTours\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/f1c8369e-4fb9-46c7-8520-b10c59011cf4/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n* [Slides](https://docs.google.com/presentation/d/174Ae7o-XWDbe4VqtfLYIptalsIBubRpo/edit)\r\n* [Recording](https://www.w3.org/2024/03/breakouts-day-2024/recordings/recording-6.html)",
       "number": 6,
       "title": "Real Estate Community Group and the Web ",
-      "day": "2024-03-12",
       "room": "Erhu",
-      "slot": "21:00"
+      "slot": "2024-03-12 21:00"
     },
     {
       "author": "hlflanagan",
@@ -186,18 +169,16 @@ export default {
       "tracks": ["identity"],
       "number": 3,
       "title": "Promote the PROPOSED Federated Identity Working Group",
-      "day": "2024-03-12",
       "room": "Ukulele",
-      "slot": "22:00"
+      "slot": "2024-03-12 22:00"
     },
     {
       "author": "marcoscaceres",
       "body": "### Session description\n\nThe following proposal is based on [this email](https://lists.w3.org/Archives/Public/public-webapps/2023OctDec/0011.html) and related discussion in the Gamepad API repo. Posted here as Chair of the WebApps WG. \n\nThis proposal for a W3C breakout session aims to address a critical limitation of the web as a platform for applications requiring low-latency response to user inputs. Despite technological advancements, the web's current input handling mechanisms are inadequate for such applications due to their dependence on the main thread.\n\nUser input APIs, which include keyboard, pointer, gamepad, HID, USB, MIDI, Bluetooth, and serial interfaces, are currently designed to register handlers on the main thread. This design results in inconsistent and unreliable response times, as the main thread is frequently occupied with other processes. This limitation adversely affects a broad range of applications, particularly those requiring precise user inputs, such as certain video games, Digital Audio Workstations (DAWs), synthesizers, and art programs that rely on touch gestures.\n\nWhile incorporating timestamps in input APIs could offer some improvement, a more effective solution is to allow these APIs to be accessible from Web Workers. This change would significantly reduce input latency issues. Some APIs are already making progress in this direction, but others, especially those tied to the DOM API like keyboard and pointer events, face more complex challenges due to their inherent link to the main thread.\n\nThis issue, recently discussed with folks involved with the Gamepad API, highlights the need for a comprehensive approach that encompasses various APIs. Therefore, this session proposal seeks to gather community input and collaboration to explore and develop solutions that enhance the web's ability to handle user inputs with the necessary low latency. This effort requires a broad perspective and collective action, addressing the current limitations and identifying feasible paths for improvement in web application responsiveness.\n\n### Session goal\n\nSee if it's feasible to route some HID events to workers\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n@reillyeon, @nondebug, @7ombie\n\n### IRC channel (Optional)\n\n#low-latency\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n_No response_\n\n### Instructions for meeting planners (Optional)\n\n_No response_\n\n### Agenda (link or inline) (Optional)\n\n_No response_\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/95000dca-932c-4b1d-a618-7a1d284d0edd/)\n\n### Meeting materials (Optional)\n\n- [Minutes](https://www.w3.org/2024/03/12-low-latency-minutes.html)",
       "number": 2,
       "title": "Low-latency input events in workers",
-      "day": "2024-03-12",
       "room": "Gamba",
-      "slot": "21:00"
+      "slot": "2024-03-12 21:00"
     }
   ]
 }

--- a/test/data/breakouts-day-2024.mjs
+++ b/test/data/breakouts-day-2024.mjs
@@ -29,99 +29,88 @@ export default {
       "body": "### Session description\n\nThe process of incubation, and some of its parameters, are not currently well-defined at W3C.  I'd like to gather perspectives to further the work on Incubation in the AB (https://github.com/w3c/AB-memberonly/blob/master/documents/Incubation.md).\n\nSome provoking questions to explore:\n- How should incubation work?\n- At what stage of \"doneness\" should work move from an incubation venue to a working group?\n- How should an incubation group be communicating their work to a broader venue to ease acceptance as a WG deliverable?\n- What expectation of incubation should there be before work is accepted into a WG, or into its charter?\n- What best practices should we define for referring to incubations?\n\n### Session goal\n\nGather input and perspectives to further the AB work on improving incubation process\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n_No response_\n\n### IRC channel (Optional)\n\n#incubation\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n#19, #20, #22\n\n### Instructions for meeting planners (Optional)\n\nThis may be related to #22.\n\n### Agenda (link or inline) (Optional)\n\n_No response_\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/637c8829-f322-4799-8787-2fefec8ce327/)\n\n### Meeting materials (Optional)\n\n- [Minutes](https://www.w3.org/2024/03/12-incubation-minutes.html)",
       "number": 24,
       "title": "Incubation: the on ramp to new work",
-      "day": "2024-03-12",
       "room": "Kora",
-      "slot": "22:00"
+      "slot": "2024-03-12 22:00"
     },
     {
       "author": "tidoust",
       "body": "### Session description\n\nHow do web developers talk about web features? What names do they use? How do these features map to specifications, fine-grained API functions and tests? What does a developer view tell us about the interoperability of the web platform?\n\nThe [`web-features` project](https://github.com/web-platform-dx/web-features), [envisioned in 2022](https://www.w3.org/2022/09/TPAC/breakouts.html#webdx) and [launched in 2023](https://www.w3.org/2023/09/TPAC/demos/web-features.html), explores the set of interoperable features of the web platform by:\n\n- Creating feature definitions, which identify and describe capabilities of web browsers.\n- Generating [Baseline](https://github.com/web-platform-dx/web-features/blob/main/docs/baseline.md) support data, which summarizes the availability of web features across key browsers and releases.\n- Publishing the `web-features` npm package, which bundles feature identifiers with Baseline statuses.\n\nDeveloped by the WebDX Community Group and contributors, web-features data leverages compatibility data from the browser-compat-data project, is already [integrated in MDN](https://developer.mozilla.org/en-US/blog/baseline-evolution-on-mdn/), [Can I Use](https://caniuse.com/css-nesting), [Web Platform Tests](https://github.com/web-platform-tests/wpt.fyi/blob/main/api/query/README.md#feature), and is starting to reach additional authors of JavaScript libraries and dashboards.\n\nLooking forward, feature identifiers at the \"right\" level make it possible to tag signals from the web community in surveys, browser standard positions, bug trackers, polyfills and usage counters. It also makes it easier to combine these signals with other projects that generate data out of specifications such as [`browser-specs`](https://github.com/w3c/browser-specs/) and [webref](https://github.com/w3c/webref).\n\nFeatures are also used in standardization groups, informally to organize discussions, but also formally to address transition requirements set forth by the W3C Process Document for advancing specifications on the Recommendation track. Within the Process, [new features](https://www.w3.org/2023/Process-20231103/#class-4) are defined as substantive changes that add new functionality, and used to assess [implementation experience](https://www.w3.org/2023/Process-20231103/#implementation-experience), document functionality that is considered [at risk](https://www.w3.org/2023/Process-20231103/#at-risk), and scope changes that may be incorporated in a specification depending on its maturity stage. This raises questions on the intersection between web-features and W3C’s standardization process, including:\n\n- Can web-features provide useful information to working groups?\n- Can it also inform the standardization process, e.g., to detect the need to transition a feature implemented by more than one browser out of incubation?\n- What additional data or tooling would make web-features a powerful tool for standards bodies?\n- How would **you** like to see web-features data presented in standards work?\n\n### Session goal\n\nShare updates on the web-features project, its use to inform the standardization process, and additional data, tooling and visualizations to make web-features a powerful tool for standards bodies.\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n@captainbrosset, @atopal\n\n### IRC channel (Optional)\n\n#web-features\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n_No response_\n\n### Instructions for meeting planners (Optional)\n\n_No response_\n\n### Agenda (link or inline) (Optional)\n\n- Presentation (20mn - see [slides](https://docs.google.com/presentation/d/e/2PACX-1vT5PiEfUCia_p-hIKu-LxQ90qwQks42FtsXTxI4wATYuG1OWEQlCnGcP7R_gENVnGUa82ZTGkQXQgRQ/pub))\n  - Web developers and web features\n  - Web features and standardization\n  - First stab at gathering signals to inform standardization process\n    - Late incubations\n    - Late Working Drafts\n    - Not-so-well supported Recommendations\n- Discussion (30mn)\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/9e7690a7-cd77-4192-ab60-337243f9b70a/)\n\n### Meeting materials (Optional)\n\n- [Minutes](https://www.w3.org/2024/03/12-web-features-minutes.html)",
       "number": 22,
       "title": "Web features, Baseline status, and standardization signals",
-      "day": "2024-03-12",
       "room": "Koto",
-      "slot": "14:00"
+      "slot": "2024-03-12 14:00"
     },
     {
       "author": "rdfguy",
       "body": "### Session description\n\nThis session will have a short presentation about the current state of the work the RDF-Star WG is undertaking, followed by Q&A and discussion.\n\n### Session goal\n\nInform interested parties about RDF-Star (aka RDF 1.2)\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n@ktk\n\n### IRC channel (Optional)\n\n#rdf-star\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n_No response_\n\n### Instructions for meeting planners (Optional)\n\nWe would prefer a in the first time slot (1-3 pm UTC).\n\n### Agenda (link or inline) (Optional)\n\n_No response_\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/0fc23324-8bf1-47b8-b0cf-1f0f31befb09/)\n\n### Meeting materials (Optional)\n\n* Minutes: TBD",
       "number": 21,
       "title": "RDF-Star and RDF 1.2",
-      "day": "2024-03-12",
       "room": "Erhu",
-      "slot": "13:00"
+      "slot": "2024-03-12 13:00"
     },
     {
       "author": "bkardell",
       "body": "### Session description\n\nThe Web has billions of users, and most users have many, many dependencies on the web. The ecosystem around the web, which includes things like web engines, is both incredibly complex and fundamentally critical.\n\nBut the model that has driven, funded, and sustained this ecosystem isn’t ideal. There is no guarantee that it will be sustainable over the long term, but beyond that, it already falls quite short of funding everything that needs to be done. There is just too much. Many things go long ignored simply because prioritization is hard, and funds are ultimately limited. This includes everything from new features in popular languages like CSS and JS up to entire languages like MathML and SVG, which have largely been the work of (often unpaid) individual contributors.\n\nIn this session, we intend to have a community discussion of alternative models for funding the web ecosystem, from collective funding pools to changes in open source project policies to changes in tax law, and beyond.\n\n### Session goal\n\nTo help further discussions toward better solutions\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n@darobin, @meyerweb\n\n### IRC channel (Optional)\n\n#ecosystem-funding\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n#17, #16, #12\n\n### Instructions for meeting planners (Optional)\n\nThose conflicts are \"nice to avoid\" but not critical.\n\n### Agenda (link or inline) (Optional)\n\n_No response_\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/413b7511-d5e7-491a-9666-0535c844d52c/)\n\n### Meeting materials (Optional)\n\n- [Minutes](https://www.w3.org/2024/03/12-ecosystem-funding-minutes.html)",
       "number": 20,
       "title": "How We Fund the Web Ecosystem",
-      "day": "2024-03-12",
       "room": "Koto",
-      "slot": "21:00"
+      "slot": "2024-03-12 21:00"
     },
     {
       "author": "rupakc",
       "body": "### Session description\n\nThe proliferation of Generative AI has disrupted many industries and is poised to change significant aspects of our society. Without guardrails, we have often seen conversational AI agents overfitting to the bias in the training data which negatively impacts users. At eyeo, we build machine learning solutions on a web-scale, and in order to ensure our models are fair and sustainable, we have taken several concrete steps to transform the input data and calibrate the model evaluation to reflect real-world scenarios. We believe it’s high time to start a discussion around having a formal framework which outlines the ethical considerations for the use of Generative AI and AI in general. During the session, we will explore the challenges and opportunities that lie ahead from a technical and social perspective.\n\nThis builds on our session on [Ethical AI during TPAC 2023](https://github.com/w3c/tpac2023-breakouts/issues/72), with a focus on Generative AI.\n\n### Session goal\n\nBrainstorm ideas on the ethics of these new and upcoming technologies (Generative AI) and discuss the implications of adopting these on a large scale from a social, economic and technical perspective.\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n@humeranoor\n\n### IRC channel (Optional)\n\n#ethical-ai\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n_No response_\n\n### Instructions for meeting planners (Optional)\n\n_No response_\n\n### Agenda (link or inline) (Optional)\n\n1. Rise of Generative AI \n2. Role of the World Wide Web in the adoption of these technologies\n3. Steps we take at eyeo to de-bias our web-scale Machine Learning models\n4. Ethical Implications of the use of these technologies\n5. The future of setting ethical standards for Generative AI\n\n#### Additional Information \n\nDuring the course of the session, we will be making use of this **[Miro Board](https://miro.com/app/board/uXjVNkFEEw8=/)**, please make sure you are able to view this. The board is password-protected at the moment. At the beginning of the session, we will share the password with all the participants. \n\nWe have also planned a short presentation at the start of the session. You can find the **[slide deck here](https://docs.google.com/presentation/d/1TdZvKi8AIsDUlWYeg9cHqRHA-tDiCuhe6m5B61o5sxs/edit#slide=id.g25c658642cb_2_1093)**\n\nFinally, while preparing for the session we made notes and organized relevant details pertaining to the existing literature on Ethics for AI and Generative AI. In case you are interested please have a look at this **[Google Doc](https://docs.google.com/document/d/1jv7_4JD0ynIV_bFdf3hqm_sg74twHbflOOYWafnQFwg/edit)**\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/27e8a549-c121-4c70-a6f9-ac987528c27f/)\n\n### Meeting materials (Optional)\n\n* Minutes: TBD",
       "number": 19,
       "title": "Ethical Implications of Generative AI",
-      "day": "2024-03-12",
       "room": "Lyre",
-      "slot": "21:00"
+      "slot": "2024-03-12 21:00"
     },
     {
       "author": "egekorkan",
       "body": "### Session description\n\nThe Web of Things Working Group is working on defining a registry mechanism where the wide WoT community, including other organizations like other SDOs, can contribute WoT bindings of existing protocols and media types. The WG has analyzed approaches within (official and not official ones) and outside of W3C and in this breakout we want to share our findings with the wide W3C, get inputs, and collaborate on building knowledge on how to manage registries for each technical report.\n\n[Slides](https://docs.google.com/presentation/d/1zWnl7yWMKPjKgtjogZGDe-8xf4KTK3KakhPY0_uhsB4/edit?usp=sharing)\n\n### Session goal\n\nDiscussion and Collection of Opinion\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n@jkRhb\n\n### IRC channel (Optional)\n\n#registries\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n_No response_\n\n### Instructions for meeting planners (Optional)\n\nIf possible, we prefer a slot between 11 and 15 CET.\n\n### Agenda (link or inline) (Optional)\n\n- Share the registry analysis of the WoT WG with everyone and get feedback\n- Discussion on managing registries in W3C\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/7c1b6bcd-9ee1-4570-ba4d-9ccad717e78f/)\n\n### Meeting materials (Optional)\n\n- [Minutes](https://www.w3.org/2024/03/12-registries-minutes.html)",
       "number": 18,
       "title": "Registries for W3C Specifications",
-      "day": "2024-03-12",
       "room": "Kora",
-      "slot": "13:00"
+      "slot": "2024-03-12 13:00"
     },
     {
       "author": "diekus",
       "body": "### Session description\r\n\r\nThis breakout session is to talk about ideas we have regarding enabling installation of web apps and web content through the platform natively. This is a new proposal that aims at democratizing application distribution. \r\n\r\nThe goals for the session are to describe and generate discussion about the challenges functionality like this might have. The session is open to the public.\r\n\r\n### Session goal\r\n\r\nDescribe and generate discussion about the challenges functionality like this might have.\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n@amandabaker\r\n\r\n### IRC channel (Optional)\r\n\r\n#installing-web-apps-breakout-2024\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n_No response_\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\n_No response_\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n_No response_\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/dbd11d7e-d721-49ce-99d2-72b91e0d7030/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n- [Minutes](https://www.w3.org/2024/03/12-installing-web-apps-breakout-2024-minutes.html)",
       "number": 17,
       "title": "Installing web apps as a new platform feature",
-      "day": "2024-03-12",
       "room": "Gamba",
-      "slot": "22:00"
+      "slot": "2024-03-12 22:00"
     },
     {
       "author": "torgo",
       "body": "### Session description\r\n\r\nThe Technical Architecture Group Privacy [task force](https://github.com/w3ctag/privacy-principles), together with participation from Privacy Interest Group, has been working on a set of [privacy principles](https://www.w3.org/TR/ethical-web-principles/) for the web. This is intended to be used by browser developers, authors of web specifications, reviewers of web specifications (such as the TAG and other groups participating in horizontal review), and web developers themselves. Now this document is going through wide review in advance of publication as a W3C Statement. We will present the principles and then have an open discussion.\r\n\r\n### Session goal\r\n\r\nIncrease awareness of the Privacy Principles, answer questions, gather feedback on how to improve the draft.\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n@darobin, @jyasskin\r\n\r\n### IRC channel (Optional)\r\n\r\n#privacy-principles\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n#12\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\nTo avoid in addition to #12: Other privacy-related sessions or sessions involving TAG members.\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n* Brief [presentation](https://github.com/w3ctag/privacy-principles/blob/main/meetings/2024-03-breakouts/slides.html) of an overview of the principles\r\n* Guided discussion\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/9330e02e-2f20-4cb0-9fe3-22fd9dcdb629/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n- [Minutes](https://github.com/w3ctag/privacy-principles/blob/main/meetings/2024-03-breakouts/minutes.md)",
       "number": 16,
       "title": "Privacy Principles for the Web",
-      "day": "2024-03-12",
       "room": "Gamba",
-      "slot": "14:00"
+      "slot": "2024-03-12 14:00"
     },
     {
       "author": "egekorkan",
       "body": "### Session description\n\nAs a follow-up of [Schemata Breakout of TPAC23](https://github.com/w3c/tpac2023-breakouts/issues/8), we want to further discuss ways to manage ontologies, schemas, and similar documents together. In the scope of the Thing Description Task Force at the Web of Things WG, we have analyzed some approaches such as LinkML, TreeLDR, Eclipse Semantic Modelling Framework, that we want to present. We have also identified that the topic of versioning, packaging, and serving these resources is a pressing topic that is not specific to the WoT. After these, we want to discuss on how to better continue the discussions in this topic area within the W3C.\n\n[Slides](https://docs.google.com/presentation/d/193OFcFaxD0GqrRuOggwZe5eorgL1C1Epe2cAYN3JEkk/edit?usp=sharing)\n\n### Session goal\n\nDiscussion and Collection of Opinion\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n_No response_\n\n### IRC channel (Optional)\n\n#schemata-discussion\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n#18\n\n### Instructions for meeting planners (Optional)\n\n_No response_\n\n### Agenda (link or inline) (Optional)\n\n- Recap of the TPAC2023 Breakout\n- Results of [the analysis](https://github.com/w3c/wot-thing-description/blob/egekorkan-patch-3/toolchain/tool-analysis.md) of tools at the WoT WG\n- Versioning, packaging and serving resources\n- Continuation of the work\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/fb7b6d9f-fc2f-456f-9fff-3a516f3ec7ab/)\n\n### Meeting materials (Optional)\n\n- [Minutes](https://www.w3.org/2024/03/12-schemata-discussion-minutes.html)",
       "number": 15,
       "title": "Schemata Discussion - Follow up from TPAC23",
-      "day": "2024-03-12",
       "room": "Kora",
-      "slot": "14:00"
+      "slot": "2024-03-12 14:00"
     },
     {
       "author": "wbamberg",
       "body": "### Session description\r\n\r\nAt the [Secure the Web Forward](https://www.w3.org/2023/03/secure-the-web-forward/report.html) workshop in 2023, writers from Open Web Docs led a [discussion about the state of web security docs on MDN](https://www.w3.org/2023/03/secure-the-web-forward/report.html#documentation). One outcome from this was that OWD would draft an outline for some improved security documentation for MDN, which would be written in 2024.\r\n\r\nWe've now written up a draft outline and it's had some internal review: https://docs.google.com/document/d/1p1GtjmTd1uQrO2PRb_uUflAfQpEsfs7hBaopYeuoPMM/edit, and we're ready for some more extensive review of the outline before we start writing docs.\r\n\r\nWe're very keen on finding security experts to collaborate with us on this project, both in these early stages as we scope the project, and for detailed technical review of documents as we write them.\r\n\r\nIn this session, we'll present the draft outline, discuss any feedback, and next steps, which we hope will be making a start on the documentation!\r\n\r\n### Session goal\r\n\r\nReview MDN web security docs outline proposal\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n_No response_\r\n\r\n### IRC channel (Optional)\r\n\r\n#mdn-security\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n#20, #22\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\nI'd prefer this to be scheduled not earlier than 4pm UTC.\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n- Present security docs outline\r\n- Discuss any questions that come up\r\n- Propose next steps for the project\r\n- Slides: https://wbamberg.github.io/web-security-w3c-breakouts-march-2024/\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/28cae5e2-8941-4d36-83fa-5a94f54a7d9a/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n- [Minutes](https://www.w3.org/2024/03/12-mdn-security-minutes.html)\r\n- [Recording](https://www.w3.org/2024/03/breakouts-day-2024/recordings/recording-14.html)",
       "number": 14,
       "title": "Web security docs for MDN",
-      "day": "2024-03-12",
       "room": "Koto",
-      "slot": "22:00"
+      "slot": "2024-03-12 22:00"
     },
     {
       "author": "wareid",
       "body": "### Session description\r\n\r\nFacilitating meetings in technical spaces is an important skill, and there are not many resources on how to do it for people new to the practice or new to W3C. Based on the [meeting facilitation training](https://www.w3.org/events/happenings/2023/meeting-facilitation-training/) developed by the Positive Work Environments CG at W3C, this session will provide a condensed version of the training covering how to effectively run meetings in a W3C context, how to handle code of conduct matters, and how to handle conflict.\r\n\r\n### Session goal\r\n\r\nProvide meeting facilitators with information and guidance on running better meetings.\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n_No response_\r\n\r\n### IRC channel (Optional)\r\n\r\n#running-meetings\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n_No response_\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\n_No response_\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n* Effective meeting facilitation\r\n  * Setting the stage \r\n  * Tooling\r\n  * Fostering discussion \r\n* Introducing the code of conduct\r\n  * Role of the facilitator\r\n* Handling difficult situations\r\n  * De-escalation\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/fa279254-9abd-42c3-af11-5bb50851154b/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n- [Minutes](https://www.w3.org/2024/03/12-running-meetings-minutes.html)\r\n- [Recording](https://www.w3.org/2024/03/breakouts-day-2024/recordings/recording-13.html)",
       "number": 13,
       "title": "Running Better Meetings - How to Facilitate at W3C",
-      "day": "2024-03-12",
       "room": "Gamba",
-      "slot": "13:00"
+      "slot": "2024-03-12 13:00"
     },
     {
       "author": "martinthomson",
@@ -129,27 +118,24 @@ export default {
       "tracks": ["identity"],
       "number": 12,
       "title": "Building Consensus on the Role of Real World Identities on the Web",
-      "day": "2024-03-12",
       "room": "Ukulele",
-      "slot": "13:00"
+      "slot": "2024-03-12 13:00"
     },
     {
       "author": "matatk",
       "body": "### Session description\r\n\r\nThe move to Github for tracking our work - including actions, and various horizontal review tasks - has been a boon for productivity, and transparency. However, it can be hard to keep up to date with all the work that's going on, especially for TF facilitators, WG chairs, people who take part in horizontal review activities, and people who find the command line more accessible.\r\n\r\nWith a hat tipped to Tracker, our long-time action management tool, APA WG has been exploring the possibilities for presenting the rich and robust GitHub process on the command line. But this isn't just for APA WG; it's intended to be of use to TF facilitators and WG chairs across W3C.\r\n\r\n### Session goal\r\n\r\nDemonstrate our command-line work tracking tool, and seek feedback from potential users\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n_No response_\r\n\r\n### IRC channel (Optional)\r\n\r\n#nu-tracker\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n#10\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\nMeeting must _start_ between 0700 and 2100 UTC.\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n* Use cases for a new interface to the GitHub process\r\n* Demo of Nu Tracker\r\n* Roadmap\r\n* Questions and feedback\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/7f29f666-3931-49f8-a44c-93bd9807ab2d/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n- [Minutes](https://www.w3.org/2024/03/breakout-nu-tracker-minutes.txt)",
       "number": 11,
       "title": "Nu Tracker: Helping you manage actions and horizontal review tasks from the command line",
-      "day": "2024-03-12",
       "room": "Lyre",
-      "slot": "13:00"
+      "slot": "2024-03-12 13:00"
     },
     {
       "author": "matatk",
       "body": "### Session description\r\n\r\nNavigation around sites can be complex, presenting barriers for people who struggle to understand the visual layout, or terminology that a site uses. However, there are several key sections or pages that can be found across many sites. The WAI-Adapt Task Force is exploring an approach (pending review) to address these barriers.\r\n\r\nThis session introduces the problem, shows how we envisage the solution working, from the user's perspective - via a demo of an interactive browser extension - and describes our proposed approach, in order to answer your questions, and gather informal feedback before we apply for horizontal and wide review from the community.\r\n\r\n### Session goal\r\n\r\nRaise awareness of the challenges of site navigation, and a potential simple, semantic, standardized solution\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n_No response_\r\n\r\n### IRC channel (Optional)\r\n\r\n#adapt\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n#11\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\nMeeting must _start_ between 0700 and 2100 UTC.\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n* Site navigation barriers\r\n* What support could look like in the browser (demo)\r\n* WAI-Adapt's proposed solution\r\n* Next steps (i.e. seeking review)\r\n* Discussion\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/0ac4bc8d-6dc8-48db-a822-7525eb9cd093/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n- [Minutes](https://www.w3.org/2024/03/12-adapt-minutes.html)\r\n- [Recording](https://www.w3.org/2024/03/breakouts-day-2024/recordings/recording-10.html)",
       "number": 10,
       "title": "Exploring making site navigation more accessible, with \"well-known destinations\"",
-      "day": "2024-03-12",
       "room": "Lyre",
-      "slot": "14:00"
+      "slot": "2024-03-12 14:00"
     },
     {
       "author": "npm1",
@@ -157,9 +143,8 @@ export default {
       "tracks": ["identity"],
       "number": 9,
       "title": "FedCM multiple IDP support",
-      "day": "2024-03-12",
       "room": "Ukulele",
-      "slot": "21:00"
+      "slot": "2024-03-12 21:00"
     },
     {
       "author": "domfarolino",
@@ -167,18 +152,16 @@ export default {
       "tracks": ["identity"],
       "number": 7,
       "title": "FedCM request settings & CORS",
-      "day": "2024-03-12",
       "room": "Ukulele",
-      "slot": "14:00"
+      "slot": "2024-03-12 14:00"
     },
     {
       "author": "JAlanBird-DO",
       "body": "### Session description\r\n\r\nThe mission of the Real Estate Community Group is to provide a forum for real estate-related technical discussions to track progress of technology features on the Web within W3C groups, educate on the use of Web technologies by external organizations, and to identify use cases and requirements that existing and/or new specifications need to meet to deliver a more inclusive, robust experiences to the Real Estate ecosystem.  This session will discuss the group, answer questions and briefly demonstrate the DO AudioTours technology built by Direct Offer.\r\n\r\nAdditional session chair: Amy Chorew.\r\n\r\n### Session goal\r\n\r\nGet support for the group\r\n\r\n### Session type\r\n\r\nBreakout (Default)\r\n\r\n### Additional session chairs (Optional)\r\n\r\n_No response_\r\n\r\n### IRC channel (Optional)\r\n\r\n#3Realestate\r\n\r\n### Other sessions where we should avoid scheduling conflicts (Optional)\r\n\r\n_No response_\r\n\r\n### Instructions for meeting planners (Optional)\r\n\r\n_No response_\r\n\r\n### Agenda (link or inline) (Optional)\r\n\r\n* Introductions \r\n* Why we're creating the CG\r\n* Who are the potential actors in the group\r\n* What it does for the real estate industry\r\n* demo of DO AudioTours\r\n\r\n### Links to calendar (Optional)\r\n\r\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/f1c8369e-4fb9-46c7-8520-b10c59011cf4/)\r\n\r\n### Meeting materials (Optional)\r\n\r\n* [Slides](https://docs.google.com/presentation/d/174Ae7o-XWDbe4VqtfLYIptalsIBubRpo/edit)\r\n* [Recording](https://www.w3.org/2024/03/breakouts-day-2024/recordings/recording-6.html)",
       "number": 6,
       "title": "Real Estate Community Group and the Web ",
-      "day": "2024-03-12",
       "room": "Erhu",
-      "slot": "21:00"
+      "slot": "2024-03-12 21:00"
     },
     {
       "author": "hlflanagan",
@@ -186,18 +169,16 @@ export default {
       "tracks": ["identity"],
       "number": 3,
       "title": "Promote the PROPOSED Federated Identity Working Group",
-      "day": "2024-03-12",
       "room": "Ukulele",
-      "slot": "22:00"
+      "slot": "2024-03-12 22:00"
     },
     {
       "author": "marcoscaceres",
       "body": "### Session description\n\nThe following proposal is based on [this email](https://lists.w3.org/Archives/Public/public-webapps/2023OctDec/0011.html) and related discussion in the Gamepad API repo. Posted here as Chair of the WebApps WG. \n\nThis proposal for a W3C breakout session aims to address a critical limitation of the web as a platform for applications requiring low-latency response to user inputs. Despite technological advancements, the web's current input handling mechanisms are inadequate for such applications due to their dependence on the main thread.\n\nUser input APIs, which include keyboard, pointer, gamepad, HID, USB, MIDI, Bluetooth, and serial interfaces, are currently designed to register handlers on the main thread. This design results in inconsistent and unreliable response times, as the main thread is frequently occupied with other processes. This limitation adversely affects a broad range of applications, particularly those requiring precise user inputs, such as certain video games, Digital Audio Workstations (DAWs), synthesizers, and art programs that rely on touch gestures.\n\nWhile incorporating timestamps in input APIs could offer some improvement, a more effective solution is to allow these APIs to be accessible from Web Workers. This change would significantly reduce input latency issues. Some APIs are already making progress in this direction, but others, especially those tied to the DOM API like keyboard and pointer events, face more complex challenges due to their inherent link to the main thread.\n\nThis issue, recently discussed with folks involved with the Gamepad API, highlights the need for a comprehensive approach that encompasses various APIs. Therefore, this session proposal seeks to gather community input and collaboration to explore and develop solutions that enhance the web's ability to handle user inputs with the necessary low latency. This effort requires a broad perspective and collective action, addressing the current limitations and identifying feasible paths for improvement in web application responsiveness.\n\n### Session goal\n\nSee if it's feasible to route some HID events to workers\n\n### Session type\n\nBreakout (Default)\n\n### Additional session chairs (Optional)\n\n@reillyeon, @nondebug, @7ombie\n\n### IRC channel (Optional)\n\n#low-latency\n\n### Other sessions where we should avoid scheduling conflicts (Optional)\n\n_No response_\n\n### Instructions for meeting planners (Optional)\n\n_No response_\n\n### Agenda (link or inline) (Optional)\n\n_No response_\n\n### Links to calendar (Optional)\n\n- [2024-03-12, 13:00-14:00](https://www.w3.org/events/meetings/95000dca-932c-4b1d-a618-7a1d284d0edd/)\n\n### Meeting materials (Optional)\n\n- [Minutes](https://www.w3.org/2024/03/12-low-latency-minutes.html)",
       "number": 2,
       "title": "Low-latency input events in workers",
-      "day": "2024-03-12",
       "room": "Gamba",
-      "slot": "21:00"
+      "slot": "2024-03-12 21:00"
     }
   ]
 }

--- a/test/data/group-meetings.mjs
+++ b/test/data/group-meetings.mjs
@@ -100,8 +100,7 @@ Invalid room in one of the meetings.`
       number: 12,
       title: 'Publishing BG',
       room: 'Room 2',
-      day: '2042-02-10',
-      meeting: '9:00; 11:00',
+      meeting: '2042-02-10, 9:00; 2042-02-10, 11:00',
       body: `
 ### Session description
 Scheduled in same room and at the same time as next session.`
@@ -134,8 +133,7 @@ More than 50`,
 ### Session description
 Schedule conflict with next joint meeting.`,
       room: 'Room 3',
-      day: '2042-02-10',
-      slot: '14:00'
+      slot: '2042-02-10 14:00'
     },
 
     {
@@ -184,8 +182,7 @@ Incoherent scheduling.`,
 Same IRC channel as next session.
 ### IRC channel (Optional)
 #debug`,
-      day: '2042-02-13',
-      slot: '16:00',
+      slot: '2042-02-13 16:00',
       meeting: 'Room 1'
     },
 
@@ -218,8 +215,7 @@ Same time as next group meeting in same track.`,
       body: `
 ### Session description
 Same time as previous group meeting in same track.`,
-      day: '2042-02-10',
-      slot: '14:00',
+      slot: '2042-02-10 14:00',
       meeting: 'Room 6'
     },
 

--- a/test/data/session-validation.mjs
+++ b/test/data/session-validation.mjs
@@ -58,8 +58,7 @@ Breakout (Default)
 ### Estimated number of in-person attendees
 fewer than 20 people`,
       room: 'Main',
-      day: '2042-04-05',
-      slot: '22:00'
+      slot: '2042-04-05 22:00'
     },
 
     {
@@ -146,8 +145,7 @@ Uncover bugs.
 ### Session type
 Breakout (Default)`,
       room: 'Main',
-      day: '2042-04-05',
-      slot: '9:00'
+      slot: '2042-04-05 9:00'
     },
 
     {
@@ -161,8 +159,7 @@ Uncover bugs.
 ### Session type
 Breakout (Default)`,
       room: 'Main',
-      day: '2042-04-05',
-      slot: '9:00'
+      slot: '2042-04-05 9:00'
     },
 
     {
@@ -176,8 +173,7 @@ Uncover bugs.
 ### Session type
 Plenary`,
       room: 'Plenary',
-      day: '2042-04-05',
-      slot: '10:00'
+      slot: '2042-04-05 10:00'
     },
 
     {
@@ -191,8 +187,7 @@ Uncover bugs.
 ### Session type
 Plenary`,
       room: 'Plenary',
-      day: '2042-04-05',
-      slot: '10:00'
+      slot: '2042-04-05 10:00'
     },
 
     {
@@ -206,8 +201,7 @@ Uncover bugs.
 ### Session type
 Plenary`,
       room: 'Plenary',
-      day: '2042-04-05',
-      slot: '10:00'
+      slot: '2042-04-05 10:00'
     },
 
     {
@@ -221,8 +215,7 @@ Uncover bugs.
 ### Session type
 Plenary`,
       room: 'Plenary',
-      day: '2042-04-05',
-      slot: '10:00'
+      slot: '2042-04-05 10:00'
     },
 
     {
@@ -238,8 +231,7 @@ Breakout (Default)
 ### Estimated number of in-person attendees
 More than 45 people`,
       room: 'Main',
-      day: '2042-04-05',
-      slot: '15:00'
+      slot: '2042-04-05 15:00'
     },
 
     {
@@ -255,8 +247,7 @@ Breakout (Default)
 ### Additional session chairs
 @tidoust`,
       room: 'Main',
-      day: '2042-04-05',
-      slot: '11:00'
+      slot: '2042-04-05 11:00'
     },
 
     {
@@ -271,8 +262,7 @@ Uncover bugs.
 ### Session type
 Breakout (Default)`,
       room: 'Secondary',
-      day: '2042-04-05',
-      slot: '11:00'
+      slot: '2042-04-05 11:00'
     },
 
     {
@@ -287,8 +277,7 @@ Uncover bugs.
 Breakout (Default)
 ### Other sessions where we should avoid scheduling conflicts (Optional)
 #17`,
-      day: '2042-04-05',
-      slot: '12:00'
+      slot: '2042-04-05 12:00'
     },
 
     {
@@ -302,8 +291,7 @@ My session is rich.
 Uncover bugs.
 ### Session type
 Breakout (Default)`,
-      day: '2042-04-05',
-      slot: '12:00'
+      slot: '2042-04-05 12:00'
     },
 
     {
@@ -318,8 +306,7 @@ Uncover bugs.
 ### Session type
 Breakout (Default)`,
       room: 'Main',
-      day: '2042-04-05',
-      slot: '13:00'
+      slot: '2042-04-05 13:00'
     },
 
     {
@@ -335,8 +322,7 @@ Uncover bugs.
 ### Session type
 Breakout (Default)`,
       room: 'Secondary',
-      day: '2042-04-05',
-      slot: '13:00'
+      slot: '2042-04-05 13:00'
     },
 
     {
@@ -350,8 +336,7 @@ Uncover bugs.
 ### Session type
 Breakout (Default)`,
       room: 'Main',
-      day: '2042-04-05',
-      slot: '14:00'
+      slot: '2042-04-05 14:00'
     },
 
     {
@@ -366,8 +351,7 @@ Uncover bugs.
 ### Session type
 Plenary`,
       room: 'Plenary',
-      day: '2042-04-05',
-      slot: '14:00'
+      slot: '2042-04-05 14:00'
     },
 
     {
@@ -383,8 +367,7 @@ Uncover bugs.
 Breakout (Default)
 ### IRC channel (Optional)
 #debug`,
-      day: '2042-04-05',
-      slot: '15:00'
+      slot: '2042-04-05 15:00'
     },
 
     {
@@ -400,8 +383,7 @@ Uncover bugs.
 Breakout (Default)
 ### IRC channel (Optional)
 #debug`,
-      day: '2042-04-05',
-      slot: '15:00'
+      slot: '2042-04-05 15:00'
     },
 
     {
@@ -443,8 +425,7 @@ Uncover bugs.
 ### Session type
 Breakout (Default)`,
       room: 'Main',
-      day: '2020-02-11',
-      slot: '9:00'
+      slot: '2020-02-11 9:00'
     },
 
     {

--- a/test/data/track-schedule-with-constraints.mjs
+++ b/test/data/track-schedule-with-constraints.mjs
@@ -20,7 +20,7 @@ export default {
       author: 'ianbjacobs',
       title: 'Session with constraint',
       tracks: ['ux'],
-      slot: '9:00',
+      slot: '2042-04-05 9:00',
       body: `
 ### Session description
 Blah

--- a/tools/add-minutes.mjs
+++ b/tools/add-minutes.mjs
@@ -14,12 +14,13 @@ import { getEnvKey } from './common/envkeys.mjs';
 import { loadProject } from './node/lib/project.mjs'
 import { validateSession } from './common/validate.mjs';
 import { updateSessionDescription } from './common/session.mjs';
+import { getProjectSlot } from './common/project.mjs';
 import todoStrings from './common/todostrings.mjs';
 
 
 async function main(number) {
   const project = await loadProject();
-  let sessions = project.sessions.filter(s => s.day && s.slot && s.room &&
+  let sessions = project.sessions.filter(s => s.slot && s.room &&
     (!number || s.number === number));
   sessions.sort((s1, s2) => s1.number - s2.number);
   if (number) {
@@ -68,10 +69,10 @@ async function main(number) {
     // TODO: date is in the timezone of the TPAC event but actual dated URL
     // is on Boston time. No big deal for TPAC meetings in US / Europe, but
     // problematic when TPAC is in Asia.
-    const day = project.days.find(day => day.name === session.day);
-    const year = day.date.substring(0, 4);
-    const month = day.date.substring(5, 7);
-    const mday = day.date.substring(8, 10);
+    const slot = getProject(project, session.slot);
+    const year = slot.date.substring(0, 4);
+    const month = slot.date.substring(5, 7);
+    const mday = slot.date.substring(8, 10);
     const url = `https://www.w3.org/${year}/${month}/${mday}-${session.description.shortname.substring(1)}-minutes.html`;
     const response = await fetch(url);
     if ((response.status !== 200) && (response.status !== 401)) {

--- a/tools/appscript/apply-schedule.mjs
+++ b/tools/appscript/apply-schedule.mjs
@@ -36,7 +36,7 @@ export default async function () {
       const sessionSchedule = schedule.find(row => row[0] === session.number);
       if (sessionSchedule) {
         session.room = sessionSchedule[1];
-        session.day = sessionSchedule[2];
+        // Note: day used to be recorded separately from slot (hence missing "2")
         session.slot = sessionSchedule[3];
         session.meeting = sessionSchedule[4];
         session.tracks = sessionSchedule[5];

--- a/tools/appscript/lib/import-from-github.mjs
+++ b/tools/appscript/lib/import-from-github.mjs
@@ -50,7 +50,6 @@ If not, ask François or Ian to run the required initialization steps.`);
       const session = project.sessions.find(s => s.number === ghSession.number);
       if (session) {
         ghSession.room = session.room;
-        ghSession.day = session.day;
         ghSession.slot = session.slot;
         ghSession.meeting = session.meeting;
         ghSession.meetings = session.meetings;

--- a/tools/appscript/lib/project.mjs
+++ b/tools/appscript/lib/project.mjs
@@ -3,6 +3,7 @@ import { parseRepositoryName } from '../../common/repository.mjs';
 import {
   parseSessionMeetings,
   serializeSessionMeetings } from '../../common/meetings.mjs';
+import { getProjectSlot } from '../../common/project.mjs';
 
 /**
  * Retrieve an indexed object that contains the list of sheets associated with
@@ -232,8 +233,7 @@ export function getProject(spreadsheet) {
             if (!meeting.slot) {
               return null;
             }
-            const slot = project.slots.find(slot =>
-              slot.date + ' ' + slot.start === meeting.slot);
+            const slot = getProjectSlot(project, meeting.slot);
             if (!slot) {
               console.warn(`The "Meetings" sheet references an unknown slot ${meeting.slot}`);
               return null;
@@ -257,8 +257,7 @@ export function getProject(spreadsheet) {
   else {
     for (const session of project.sessions) {
       if (session.slot) {
-        const slot = project.slots.find(slot =>
-          slot.date + ' ' + slot.start === session.slot);
+        const slot = getProjectSlot(project, session.slot);
         if (slot) {
           session.meeting = null;
           session.meetings = [

--- a/tools/appscript/lib/schedule.mjs
+++ b/tools/appscript/lib/schedule.mjs
@@ -1,5 +1,6 @@
 import { groupSessionMeetings } from '../../common/meetings.mjs';
 import { Srand } from '../../common/jsrand.mjs';
+import { getProjectSlot } from '../../common/project.mjs';
 
 /**
  * Fill the grid in the provided spreadsheet
@@ -27,7 +28,8 @@ export function fillGridSheet(spreadsheet, project, validationErrors) {
   const metadata = project.sessions.map(session => [
     session.number,
     session.room,
-    session.day,
+    // Note: day used to be recorded separately from slot
+    '',
     session.slot,
     session.meeting,
     session.tracks
@@ -321,12 +323,13 @@ function addSessions(sheet, project, validationErrors) {
         return session.meetings.map(meeting =>
           Object.assign({ number: session.number }, meeting));
       }
-      else if (session.room && session.day && session.slot) {
+      else if (session.room && session.slot) {
+        const slot = getProjectSlot(project, session.slot);
         return {
           number: session.number,
           room: session.room,
-          day: session.day,
-          slot: session.slot
+          day: slot?.date,
+          slot: slot?.slot
         };
       }
       else {

--- a/tools/appscript/propose-grid.mjs
+++ b/tools/appscript/propose-grid.mjs
@@ -57,7 +57,7 @@ async function proposeGrid(spreadsheet) {
     const preserveAll = options.preserve?.includes('all');
     if (preserveAll) {
       options.preserve = project.sessions
-        .filter(s => s.meeting || s.day || s.slot || s.room)
+        .filter(s => s.meeting || s.slot || s.room)
         .map(s => s.number);
     }
     if (options.except) {

--- a/tools/common/meetings.mjs
+++ b/tools/common/meetings.mjs
@@ -1,3 +1,5 @@
+import { getProjectSlot } from './project.mjs';
+
 /**
  * Normalize times for comparison purpose, making sure that hours always have
  * two digits: from 9:00 to 09:00
@@ -72,14 +74,15 @@ function validateActualTimes(meeting, project) {
  * `meeting` field.
  */
 export function parseSessionMeetings(session, project) {
+  const sessionSlot = getProjectSlot(project, session.slot);
   if (session.meeting) {
     return session.meeting.split(/;|\|/)
       .map(str => str.trim())
       .map(str => {
         const meeting = {
           room: session.room,
-          day: session.day,
-          slot: session.slot
+          day: sessionSlot?.date,
+          slot: sessionSlot?.start
         };
         str.split(',')
           .map(token => token.trim().toLowerCase())
@@ -154,20 +157,15 @@ export function parseSessionMeetings(session, project) {
       });
   }
   
-  if (session.room || session.day || session.slot) {
+  if (session.room || sessionSlot) {
     // One meeting at least partially scheduled
     const meeting = {};
     if (session.room) {
       meeting.room = session.room;
     }
-    if (session.day) {
-      meeting.day = session.day;
-    }
-    if (session.slot) {
-      meeting.slot = session.slot;
-    }
-    if (session.day && session.slot) {
-      meeting.name = session.day + ' ' + meeting.slot;
+    if (sessionSlot) {
+      meeting.day = sessionSlot.date;
+      meeting.slot = sessionSlot.start;
     }
     return [meeting];
   }

--- a/tools/common/project.mjs
+++ b/tools/common/project.mjs
@@ -158,7 +158,8 @@ async function exportSchedule(project) {
   const schedule = project.sessions.map(session => [
     session.number,
     session.room,
-    session.day,
+    // Note: day used to be recorded separately from slot
+    '',
     session.slot,
     session.meeting,
     session.tracks
@@ -346,4 +347,10 @@ async function fetchSessions(reponame) {
       repository: session.repository.nameWithOwner,
       labels: session.labels.nodes.map(label => label.name)
     }));
+}
+
+
+export function getProjectSlot(project, dayAndTime) {
+  return project.slots.find(slot =>
+    (slot.date + ' ' + slot.start) === dayAndTime);
 }

--- a/tools/common/schedule.mjs
+++ b/tools/common/schedule.mjs
@@ -31,6 +31,7 @@ import { parseSessionMeetings,
          meetsInParallelWith,
          meetsInRoom,
          meetsAt } from './meetings.mjs';
+import { getProjectSlot } from './project.mjs';
 
 function getRequestedNbOfSlots(session) {
   if (session.description.times?.length) {
@@ -333,11 +334,12 @@ export function suggestSchedule(project, { seed }) {
       else {
         // Prepare a list of meetings that we want to schedule
         baseMeetings = [];
+        const sessionSlot = getProjectSlot(project, session.slot);
         for (let i = 0; i < numberOfMeetings; i++) {
           baseMeetings.push({
-            day: session.day,
             room: session.room,
-            slot: session.slot
+            day: sessionSlot?.date,
+            slot: sessionSlot?.slot
           });
         }
       }
@@ -503,8 +505,7 @@ export function suggestSchedule(project, { seed }) {
           }
           else {
             session.room = meetings[0].room;
-            session.day = meetings[0].day;
-            session.slot = meetings[0].slot;
+            session.slot = meetings[0].day + ' ' + meetings[0].slot;
           }
           session.meetings = meetings;
           session.updated = true;

--- a/tools/minutes-to-w3c.mjs
+++ b/tools/minutes-to-w3c.mjs
@@ -17,7 +17,7 @@ import fs from 'node:fs/promises';
 
 async function main(number, minutesPrefix) {
   const project = await loadProject();
-  let sessions = project.sessions.filter(s => s.day && s.slot && s.room &&
+  let sessions = project.sessions.filter(s => s.slot && s.room &&
     (!number || s.number === number));
   sessions.sort((s1, s2) => s1.number - s2.number);
   if (number) {

--- a/tools/node/schedule.mjs
+++ b/tools/node/schedule.mjs
@@ -67,7 +67,7 @@ export default async function (project, options) {
   const preserveAll = options.preserve?.includes('all');
   if (preserveAll) {
     options.preserve = project.sessions
-      .filter(s => s.meeting || s.day || s.slot || s.room)
+      .filter(s => s.meeting || s.slot || s.room)
       .map(s => s.number);
   }
   if (options.except) {

--- a/tools/setup-irc.mjs
+++ b/tools/setup-irc.mjs
@@ -64,7 +64,7 @@ async function waitForIRCMessage(what) {
  */
 async function main({ number, onlyCommands, dismissBots } = {}) {
   const project = await loadProject();
-  let sessions = project.sessions.filter(s => s.day && s.slot &&
+  let sessions = project.sessions.filter(s => s.slot &&
     (!number || s.number === number));
   sessions.sort((s1, s2) => s1.number - s2.number);
   if (number) {


### PR DESCRIPTION
The `slot` property of sessions stores both the date and the start time of the meeting. It used to store only the meeting times, while the date used to be captured in a `day` property.

The code still handled or incorrectly *expected* the day property here and there. This update properly drops the possibility to set a schedule day at the session level in a `day` property, and adjusts tests accordingly.

Internally, atomic meetings are presented with a `day` property that contains the date of the meeting and a `slot` property that contains the start time. That's normal although certainly unfortunate that the same terminology be used. Merged meetings rather use `start` to record the meeting start time.