### PR TITLE
Avoid conflicts with joint meetings of conflicting groups too

### DIFF
--- a/test/check-indirect-conflicts.mjs
+++ b/test/check-indirect-conflicts.mjs
@@ -1,0 +1,34 @@
+import * as assert from 'node:assert';
+import { initTestEnv } from './init-test-env.mjs';
+import { setEnvKey } from '../tools/common/envkeys.mjs';
+import { loadProject } from '../tools/node/lib/project.mjs';
+import { validateSession } from '../tools/common/validate.mjs';
+
+function stripDetails(errors) {
+  return errors.map(err => {
+    if (err.details) {
+      delete err.details;
+    }
+    return err;
+  });
+}
+
+describe('Joint meeting handling', function () {
+  before(function () {
+    initTestEnv();
+    setEnvKey('REPOSITORY', 'test/conflicts-indirect');
+    setEnvKey('ISSUE_TEMPLATE', 'test/data/template-group.yml');
+  });
+
+  it('detects indirect conflicts', async function () {
+    const project = await loadProject();
+    const sessionNumber = 4;
+    const errors = await validateSession(sessionNumber, project);
+    assert.deepStrictEqual(stripDetails(errors), [{
+      session: sessionNumber,
+      severity: 'warning',
+      type: 'conflict',
+      messages: ['Same day/slot "2042-02-10 11:00" as conflicting session "Media WG & Web Real-Time Communications WG joint meeting" (#3)']
+    }]);
+  });
+});

--- a/test/data/conflicts-indirect.mjs
+++ b/test/data/conflicts-indirect.mjs
@@ -1,0 +1,67 @@
+export default {
+  metadata: {
+    meeting: 'Indirect conflicts test event',
+    timezone: 'Etc/UTC',
+    type: 'groups'
+  },
+
+  slots: [
+    '2042-02-10 9:00 - 11:00',
+    '2042-02-10 11:00 - 13:00',
+    '2042-02-10 14:00 - 16:00',
+    '2042-02-10 16:00 - 18:00',
+    '2042-02-11 9:00 - 11:00',
+    '2042-02-11 11:00 - 13:00',
+    '2042-02-11 14:00 - 16:00',
+    '2042-02-11 16:00 - 18:00',
+    '2042-02-13 9:00 - 11:00',
+    '2042-02-13 11:00 - 13:00',
+    '2042-02-13 14:00 - 16:00',
+    '2042-02-13 16:00 - 18:00',
+    '2042-02-14 9:00 - 11:00',
+    '2042-02-14 11:00 - 13:00',
+    '2042-02-14 14:00 - 16:00',
+    '2042-02-14 16:00 - 18:00'
+  ],
+
+  rooms: [
+    'Room 1',
+    'Room 2'
+  ],
+
+  sessions: [
+    {
+      number: 1,
+      title: 'Media WG',
+      slot: '2042-02-10 9:00',
+      room: 'Room 1'
+    },
+
+    {
+      number: 2,
+      title: 'Web Real-Time Communications WG',
+      slot: '2042-02-10 9:00',
+      room: 'Room 2'
+    },
+
+    {
+      number: 3,
+      title: 'Media WG & Web Real-Time Communications WG joint meeting',
+      slot: '2042-02-10 11:00',
+      room: 'Room 1'
+    },
+
+    {
+      number: 4,
+      title: 'Timed Text WG',
+      body: `
+### Session description
+No conflict with Media WG, and by extension with Media WG joint meetings
+### Other meetings where we should avoid scheduling conflicts (Optional)
+#1
+        `,
+      slot: '2042-02-10 11:00',
+      room: 'Room 2'
+    }
+  ]
+}

--- a/tools/appscript/lib/schedule.mjs
+++ b/tools/appscript/lib/schedule.mjs
@@ -493,9 +493,36 @@ function addSessions(sheet, project, validationErrors) {
         error.issue.type === 'conflict');
 
     if (session.description.conflicts?.length) {
-      tokens.push({ label: '\nAvoid conflicts with: ' });
+      tokens.push({ label: '\nAvoid conflicts with ' });
       let first = true;
       for (const number of session.description.conflicts) {
+        if (!first) {
+          tokens.push({ label: ', ' });
+        }
+        first = false;
+        const hasConflict = conflictIssues.some(error =>
+          error.detail.conflictsWith.number === number);
+        const token = {
+          label: '' + number,
+          href: `${sessionsSheetUrl}&range=${findSessionRange(project, number)}`
+        };
+        tokens.push(token);
+        if (hasConflict) {
+          token.style = conflictHighlight;
+          tokens.push({
+            label: '!',
+            style: conflictHighlight
+          });
+        }
+      }
+    }
+
+    // And note there may be indirect conflicts
+    if (session.indirectConflicts?.length) {
+      const plural = session.indirectConflicts.length > 1 ? 's' : '';
+      tokens.push({ label: ` and joint meeting${plural} ` });
+      let first = true;
+      for (const number of session.indirectConflicts) {
         if (!first) {
           tokens.push({ label: ', ' });
         }

--- a/tools/common/schedule.mjs
+++ b/tools/common/schedule.mjs
@@ -288,7 +288,9 @@ export function suggestSchedule(project, { seed }) {
       if (meetConflicts.includes('session')) {
         const sessionConflict = potentialConflicts.find(s =>
           session.description.conflicts?.includes(s.number) ||
-          s.description.conflicts?.includes(session.number));
+          session.indirectConflicts?.includes(s.number) ||
+          s.description.conflicts?.includes(session.number) ||
+          s.indirectConflicts?.includes(session.number));
         if (sessionConflict) {
           return false;
         }


### PR DESCRIPTION
Via #255. When Group A says "don't conflict with group Z" then the scheduler should also avoid conflicts between the A schedule and any (joint) meeting involving Z.

This update applies the logic to the scheduler and validation. It also completes the description of group sessions in the schedule grid with the list of indirect conflicts, highlighting those that create problems.