### PR TITLE
Fetch registration information from W3C endpoint

### DIFF
--- a/test/stubs.mjs
+++ b/test/stubs.mjs
@@ -363,6 +363,9 @@ export async function importVariableFromGitHub(name) {
   else if (name === 'REGISTRANTS') {
     return null;
   }
+  else if (name === 'PEOPLE') {
+    return null;
+  }
   else {
     throw new Error(`No test data for ${name}`);
   }

--- a/tools/appscript/add-custom-menu.mjs
+++ b/tools/appscript/add-custom-menu.mjs
@@ -24,6 +24,13 @@ export default function () {
         .addItem('Fetch event info, rooms, days, slots (from GitHub)', 'importMetadata')
         .addItem('Export event info, rooms, days, slots (to GitHub)', 'exportMetadata')
         .addItem('Export event to files (HTML, JSON)', 'exportEventToFiles')
+        .addSubMenu(
+          SpreadsheetApp.getUi()
+            .createMenu('For TPAC group meetings only')
+            .addItem('Set authorization token', 'setAuthorizationToken')
+            .addItem('Refresh list of registrants per group', 'fetchRegistrants')
+            .addItem('Export emails of group chairs/team contacts', 'exportEmails')
+        )
     )
     .addToUi();
 }

--- a/tools/appscript/apply-schedule.mjs
+++ b/tools/appscript/apply-schedule.mjs
@@ -3,6 +3,7 @@ import {
 } from './lib/project.mjs';
 import reportError from './lib/report-error.mjs';
 import { fetchMapping } from './lib/w3cid-map.mjs';
+import { fetchRegistrants } from '../common/registrants.mjs';
 import { validateGrid } from '../common/validate.mjs';
 import { parseSessionMeetings } from '../common/meetings.mjs';
 
@@ -47,6 +48,12 @@ export default async function () {
       }
     }
     console.log('Apply the schedule... done');
+
+    if (project.metadata.type === 'groups') {
+      console.log('Fetch registrants...');
+      await fetchRegistrants(project);
+      console.log('Fetch registrants... done');
+    }
 
     console.log(`Validate new schedule...`);
     const { errors: newErrors, changes: newChanges } = await validateGrid(project, { what: 'scheduling' })

--- a/tools/appscript/export-emails.mjs
+++ b/tools/appscript/export-emails.mjs
@@ -1,0 +1,56 @@
+import { getProject } from './lib/project.mjs';
+import reportError from './lib/report-error.mjs';
+
+export default async function () {
+  try {
+    console.log('Read data from spreadsheet...');
+    const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+    const project = getProject(spreadsheet);
+    console.log('Read data from spreadsheet... done');
+
+    if (project.metadata.type !== 'groups') {
+      reportError(`I can only export emails for TPAC group meetings events".`);
+      return;
+    }
+
+    const people = project.sessions
+      .flatMap(session => session.people ?? [])
+      .filter((person, idx, arr) =>
+        arr.findIndex(p =>
+          p.email === person.email &&
+          p.type === person.type) === idx);
+    const chairs = people
+      .filter(p => p.type === 'Chair')
+      .map(p => `${p.name} <${p.email}>`);
+    const teamContacts = people
+      .filter(p => p.type !== 'Chair')
+      .map(p => `${p.name} <${p.email}>`);
+
+    console.log('Report result...');
+    const htmlOutput = HtmlService
+      .createHtmlOutput(
+        (chairs.length > 0 || teamContacts.length > 0) ?
+          `<p>
+            Use the following list of emails to target Chairs of groups
+            set to meet at TPAC:
+          </p>
+          <p>${chairs.join('<br/>')}</p>
+
+          <p>
+            Use the following list of emails to target Team contacts of groups
+            set to meet at TPAC:
+          </p>
+          <p>${teamContacts.join('<br/>')}</p>` :
+          `<p>No people found.
+          Note export can only work once registration has started.</p>`
+      )
+      .setWidth(300)
+      .setHeight(400);
+    SpreadsheetApp.getUi().showModalDialog(htmlOutput, 'Get list of emails');
+    console.log('Report result... done');
+  }
+  catch(err) {
+    reportError(err.toString());
+    return;
+  }
+}

--- a/tools/appscript/fetch-registrants.mjs
+++ b/tools/appscript/fetch-registrants.mjs
@@ -1,0 +1,47 @@
+import reportError from './lib/report-error.mjs';
+import { getProject, refreshProject } from './lib/project.mjs';
+import { getEnvKey } from '../common/envkeys.mjs';
+import { fetchRegistrants } from '../common/registrants.mjs';
+
+export default async function () {
+  try {
+    console.log('Read data from spreadsheet...');
+    const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+    const project = getProject(spreadsheet);
+    console.log('Read data from spreadsheet... done');
+
+    if (project.metadata.type !== 'groups') {
+      reportError(`Cannot retrieve the list of registrants as event is not of type "TPAC group meetings".
+
+    Check the "Type" parameter in the "Event" sheet.`);
+      return;
+    }
+
+    if (!project.metadata.slug) {
+      reportError(`Happy to oblige, but I need the event's slug!
+
+  Make sure that the "Meeting slug" parameter is set in the "Event" sheet.`);
+      return;
+    }
+
+    const W3C_TOKEN = await getEnvKey('W3C_TOKEN', '');
+    if (!W3C_TOKEN) {
+      reportError(`Happy to oblige, but I need an authorization token.
+
+  Use the "Set authorization token" menu in "Event > Advanced > For TPAC group meetings only".`);
+      return;
+    }
+
+    console.log('Fetch the list of registrants...');
+    await fetchRegistrants(project);
+    console.log('Fetch the list of registrants... done');
+
+    console.log('Refresh info in spreadsheet...');
+    refreshProject(spreadsheet, project, { what: 'registrants' });
+    console.log('Refresh info in spreadsheet... done');
+  }
+  catch(err) {
+    reportError(err.toString());
+    return;
+  }
+}

--- a/tools/appscript/lib/import-from-github.mjs
+++ b/tools/appscript/lib/import-from-github.mjs
@@ -2,6 +2,7 @@ import { getProject } from './project.mjs';
 import reportError from './report-error.mjs';
 import { parseRepositoryName } from '../../common/repository.mjs';
 import { fetchProjectFromGitHub } from '../../common/project.mjs';
+import { fetchRegistrants } from '../../common/registrants.mjs';
 import { validateGrid } from '../../common/validate.mjs';
 import { refreshProject } from './project.mjs';
 import { fetchMapping } from './w3cid-map.mjs';
@@ -59,10 +60,16 @@ If not, ask François or Ian to run the required initialization steps.`);
       }
     }
   }
+  project.sessions = githubProject.sessions;
   console.log('Fetch data from GitHub... done');
 
+  if (project.metadata.type === 'groups') {
+    console.log('Fetch registrants...');
+    await fetchRegistrants(project);
+    console.log('Fetch registrants... done');
+  }
+
   console.log('Validate the grid...');
-  project.sessions = githubProject.sessions;
   const res = await validateGrid(project, { what: 'everything' });
   for (const change of res.changes) {
     console.warn(`- save changes for session ${change.number}`);

--- a/tools/appscript/main.mjs
+++ b/tools/appscript/main.mjs
@@ -26,6 +26,9 @@ import _exportMetadata from './export-metadata.mjs';
 import _exportEventToFiles from './export-event-to-files.mjs';
 import _applySchedule from './apply-schedule.mjs';
 import _createRepository from './create-repository.mjs';
+import _setAuthorizationToken from './set-authorization-token.mjs';
+import _fetchRegistrants from './fetch-registrants.mjs';
+import _exportEmails from './export-emails.mjs';
 
 function main() { _createOnOpenTrigger(); }
 function addTPACMenu() { _addTPACMenu(); }
@@ -39,3 +42,6 @@ function exportMetadata() { _exportMetadata(); }
 function exportEventToFiles() { _exportEventToFiles(); }
 function applySchedule() { _applySchedule(); }
 function createRepository() { _createRepository(); }
+function setAuthorizationToken() { _setAuthorizationToken(); }
+function fetchRegistrants() { _fetchRegistrants(); }
+function exportEmails() { _exportEmails(); }

--- a/tools/appscript/set-authorization-token.mjs
+++ b/tools/appscript/set-authorization-token.mjs
@@ -1,0 +1,56 @@
+import reportError from './lib/report-error.mjs';
+
+export default async function () {
+  try {
+    console.log('Read authorization token from spreadsheet...');
+    const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+    const tokenMetadata = spreadsheet.getDeveloperMetadata()
+      .find(d => d.getKey() === 'W3C_TOKEN');
+    console.log(tokenMetadata ? '- token already set' : '- no token set for now');
+    console.log('Read data from spreadsheet... done');
+
+    console.log('Get authorization token from user...');
+    const ui = SpreadsheetApp.getUi();
+    let token = '';
+    const response = ui.prompt(
+      (tokenMetadata ?
+        'Note: The spreadsheet is already associated with an authorization token, ' +
+        'you should only need to update it if the token changed!\n\n' :
+        '') +
+      'Please provide the authorization token to use to retrieve the list of registrants and interact with the calendar.\n\n' +
+      'Hit "Cancel" to cancel the edition' +
+      (tokenMetadata ? ' and keep the current token' : '') + '.',
+      ui.ButtonSet.OK_CANCEL);
+    if (response.getSelectedButton() === ui.Button.OK) {
+      console.log('- new token provided by user');
+      token = response.getResponseText();
+    }
+    else {
+      console.log('- no token provided');
+      token = null;
+    }
+    console.log('Get authorization token from user... done');
+
+    if (token !== null) {
+      console.log('Save authorization token to spreadsheet...');
+      if (token === '') {
+        if (tokenMetadata) {
+          tokenMetadata.remove();
+        }
+      }
+      else {
+        if (tokenMetadata) {
+          tokenMetadata.setValue(token);
+        }
+        else {
+          spreadsheet.addDeveloperMetadata('W3C_TOKEN', token);
+        }
+      }
+      console.log('Save authorization token to spreadsheet... done');
+    }
+  }
+  catch(err) {
+    reportError(err.toString());
+    return;
+  }
+}

--- a/tools/common/envkeys.mjs
+++ b/tools/common/envkeys.mjs
@@ -47,6 +47,15 @@ export async function getEnvKey(key, defaultValue, json) {
 
   // Retrieve the variable from sheet environment properties if the code
   // runs within the context of an AppScript.
+  if (typeof SpreadsheetApp !== 'undefined') {
+    const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+    const value = spreadsheet.getDeveloperMetadata()
+      .find(d => d.getKey() === key)
+      ?.getValue();
+    if (value) {
+      return value;
+    }
+  }
   if (typeof PropertiesService !== 'undefined') {
     const scriptProperties = PropertiesService.getScriptProperties();
     const value = scriptProperties.getProperty(key);

--- a/tools/common/registrants.mjs
+++ b/tools/common/registrants.mjs
@@ -1,0 +1,90 @@
+import { getEnvKey } from './envkeys.mjs';
+import wrappedFetch from './wrappedfetch.mjs';
+
+/**
+ * Collect information about group meetings from the registration system.
+ *
+ * Main piece of information is the list of registrants for each and every
+ * meeting. The information also includes the emails of the group chairs
+ * and staff contacts.
+ */
+export async function fetchRegistrants(project) {
+  if (!project.metadata.slug) {
+    throw new Error('Big meeting slug is missing');
+  }
+
+  const W3C_TOKEN = await getEnvKey('W3C_TOKEN');
+  let res = await wrappedFetch(
+    `https://www.w3.org/register/${project.metadata.slug}/stats/`,
+    {
+      method: 'GET',
+      headers: {
+        'Authorization': `token ${W3C_TOKEN}`,
+        'Accept': 'application/json'
+      }
+    }
+  );
+  if (res.status === 200) {
+    const json = await res.json();
+    mapRegistrantsToProject(project, json);
+    return;
+  }
+  else if (res.status === 404) {
+    return;
+  }
+  else {
+    throw new Error(`W3C server returned an unexpected HTTP status ${res.status} for GET request on registrants for ${project.metadata.slug}`);
+  }
+}
+
+
+function mapRegistrantsToProject(project, registrants) {
+  project.registrants = registrants.meetings;
+  for (const session of project.sessions) {
+    const sessionRegistrants = registrants.meetings?.find(meeting =>
+      session.groups.length === meeting.groups.length &&
+      session.groups.every(group =>
+        meeting.groups.find(g => g.name === group.name)
+      )
+    );
+    if (sessionRegistrants) {
+      session.people = sessionRegistrants.chairs
+        .map(person => Object.assign({
+            name: person.name,
+            email: person.email,
+            type: 'Chair'
+          }))
+        .concat(
+          sessionRegistrants['team-contacts']
+            .map(person => Object.assign({
+              name: person.name,
+              email: person.email,
+              type: 'Team contact'
+            })));
+    }
+    else {
+      session.people = [];
+    }
+    for (const meeting of session.meetings ?? []) {
+      const meetingRegistrants = sessionRegistrants
+        ?.sessions
+        ?.find(m => m.day === meeting.day);
+      if (meetingRegistrants) {
+        meeting.participants = meetingRegistrants['physical-participants'];
+        meeting.observers = meetingRegistrants['physical-observers'];
+      }
+      else {
+        meeting.participants = 0;
+        meeting.observers = 0;
+      }
+    }
+    if (session.meetings?.length > 0) {
+      session.participants = Math.max(...session.meetings.map(m => m.participants));
+      session.observers = Math.max(...session.meetings.map(m => m.observers));
+    }
+    else {
+      session.participants = 0;
+      session.observers = 0;
+    }
+  }
+}


### PR DESCRIPTION
This makes the code fetch registration information from a dedicated endpoint. For that to be possible, the code needs:
1. the big meeting's slug. To be added to the Event sheet. Longer term, this should completely replace the big meeting's name. In the meantime, the name is still needed to manage interaction with the calendar.
2. an authorization token. To be set once through a dedicated "Advanced" menu. The token is stored as developer metadata within the spreadsheet. This at least hides it from sight, as tokens should be (any sufficiently motivated person would be able to retrieve it, but then the spreadsheet should remain team-only so it does not really matter).

With these two pieces of information, the code retrieves the information from a W3C server:
- Registration information gets stored in the Meetings sheet
- Chairs/Staff contact information gets stored in a People sheet

Validation uses that information to alert about capacity issues.

Note: The scheduler does not look at the number of participants when it assigns rooms for now.