### PR TITLE
Add export view that mimics info in W3C admin interface

### DIFF
--- a/tools/appscript/export-event-to-files.mjs
+++ b/tools/appscript/export-event-to-files.mjs
@@ -1,7 +1,9 @@
 import { getProject } from './lib/project.mjs';
 import reportError from './lib/report-error.mjs';
 import { fetchMapping } from './lib/w3cid-map.mjs';
-import { convertProjectToHTML } from '../common/project2html.mjs';
+import {
+  convertProjectToHTML,
+  convertProjectToRegistrationHTML } from '../common/project2html.mjs';
 
 
 export default function () {
@@ -27,10 +29,19 @@ async function exportEventToFiles(spreadsheet) {
     const html = await convertProjectToHTML(project, options);
     console.log('Convert to HTML... done');
 
+    console.log('Convert to registration table...');
+    const registrationHtml = await convertProjectToRegistrationHTML(project);
+    console.log('Convert to registration table... done');
+
     console.log('Create data URL for the HTML export...');
     const htmlBase64 = Utilities.base64Encode(html, Utilities.Charset.UTF_8);
     const htmlDataUrl = `data:text/html;charset=UTF8;base64,${htmlBase64}`;
     console.log('Create data URL for the HTML export... done');
+
+    console.log('Create data URL for the registration table...');
+    const registrationBase64 = Utilities.base64Encode(registrationHtml, Utilities.Charset.UTF_8);
+    const registrationDataUrl = `data:text/html;charset=UTF8;base64,${registrationBase64}`;
+    console.log('Create data URL for the registration table... done');
 
     console.log('Create data URL for the JSON export...');
     const jsonBase64 = Utilities.base64Encode(
@@ -48,12 +59,17 @@ async function exportEventToFiles(spreadsheet) {
         <ul>
           <li>
             <a href="${htmlDataUrl}" download="event.html">
-              Download event schedule as an HTML file
+              Event schedule (HTML file)
+            </a>
+          </li>
+          <li>
+            <a href="${registrationDataUrl}" download="registration.html">
+              Registration form view (HTML file)
             </a>
           </li>
           <li>
             <a href="${jsonDataUrl}" download="event.json">
-              Download event data as a JSON file
+              Event data (JSON file)
             </a>
           </li>
         </ul>

--- a/tools/common/project2html.mjs
+++ b/tools/common/project2html.mjs
@@ -544,3 +544,111 @@ export async function convertProjectToHTML(project, cliParams) {
   writeLine(0, `</html>`);
   return html;
 }
+
+
+/**
+ * Converts a TPAC group meetings project to an HTML page that lists the
+ * meetings in a form that aligns with the admin view at:
+ * https://www.w3.org/admin/tpac-meetings/list
+ *
+ * This HTML page is aimed at simplifying the process of creating the
+ * registration form (pending complete automation?)
+ */
+export async function convertProjectToRegistrationHTML(project) {
+  // Validate project sessions. Note this is done to expand sessions with
+  // useful info (groups, meetings)
+  await validateGrid(project);
+
+  const rows = project.sessions.map(session => {
+    const days = (session.meetings ?? [])
+      .map(meeting => meeting.day)
+      .filter(day => !!day)
+      .filter((day, idx, arr) => arr.indexOf(day) === idx)
+      .sort();
+    const groups = (session.groups ?? [])
+      .map(group => group.name)
+      .sort();
+    return `<tr>
+          <td>${session.title}</td>
+          <td>${project.metadata.meeting ?? project.metadata.slug}</td>
+          <td>${days.join(', ')}</td>
+          <td>${groups.join(', ')}</td>
+        </tr>`;
+  });
+  return `<html>
+  <head>
+    <meta charset="utf-8">
+    <title>${project.metadata.meeting} - Group meetings</title>
+    <style>
+      /* Table styles and colors adapted from Pure CSS:
+       * https://github.com/pure-css/pure
+       * ... under a BSD License:
+       * https://github.com/pure-css/pure/blob/master/LICENSE
+       */
+      table {
+        border-collapse: collapse;
+        border-spacing: 0;
+        empty-cells: show;
+        border: 1px solid #cbcbcb;
+      }
+      table caption {
+        color: #000;
+        font: italic 85%/1 arial, sans-serif;
+        padding: 1em 0;
+        text-align: center;
+      }
+      table td,
+      table th {
+        border-left: 1px solid #cbcbcb;
+        border-bottom: 1px solid #cbcbcb;
+        border-width: 0 0 1px 1px;
+        font-size: inherit;
+        margin: 0;
+        overflow: visible;
+        padding: 0.5em 1em;
+      }
+      table thead {
+        background-color: #e0e0e0;
+        color: #000;
+        text-align: left;
+        vertical-align: bottom;
+      }
+      .conflict-error { background-color: #ddaeff; color: #8156a7; }
+      .capacity-error { background-color: #fcebbd; color: #af9540; }
+      .track-error { background-color: #e1f2fa; color: #5992aa; }
+      .scheduling-error { background-color: #f5ab9e; color: #8c3a2b; }
+      .scheduling-warning { background-color: #fcebbd; color: #8c3a2b; }
+      .track {
+        display: inline-block;
+        background-color: #0E8A16;
+        color: white;
+        border: 1px transparent;
+        border-radius: 1em;
+        margin-top: 0.2em;
+        margin-bottom: 0.2em;
+        padding: 3px 10px;
+        font-size: smaller;
+        white-space: nowrap;
+      }
+      .nbrooms { font-weight: normal; }
+    </style>
+    <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/base.css" type="text/css"/>
+  </head>
+  <body>
+    <h1>${project.metadata.meeting}</h1>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Event</th>
+          <th>Days</th>
+          <th>Groups</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${rows.join('\n        ')}
+      </tbody>
+    </table>
+  </body>
+</html>`;
+}


### PR DESCRIPTION
To ask TPAC registrants about what groups they plan to attend, the list of group meetings needs to be added to the registration form in the W3C admin interface.

This process could be automated in the long term. In the short term, this proposes a new HTML file to the "Export event to files" advanced menu that mimics what the resulting table should look like in the W3C admin interface: https://www.w3.org/admin/tpac-meetings/list