### PR TITLE
Make sure room names are always interpreted as plain text

### DIFF
--- a/tools/appscript/lib/project.mjs
+++ b/tools/appscript/lib/project.mjs
@@ -744,7 +744,9 @@ function createSessionsSheet(spreadsheet, sheets, project) {
     const roomRange = sheet.getRange(
       2, headers.findIndex(h => h === 'Room') + 1,
       sheet.getMaxRows() - 1, 1);
-    roomRange.setDataValidation(roomRule);
+    roomRange
+      .setNumberFormat('@')
+      .setDataValidation(roomRule);
 
     const slotValues = project.slots.map(slot =>
       slot.date + ' ' + slot.start);
@@ -756,7 +758,9 @@ function createSessionsSheet(spreadsheet, sheets, project) {
     const slotRange = sheet.getRange(
       2, headers.findIndex(h => h === 'Slot') + 1,
       sheet.getMaxRows() - 1, 1);
-    slotRange.setDataValidation(slotRule);
+    slotRange
+      .setNumberFormat('@')
+      .setDataValidation(slotRule);
   }
 
   sheet


### PR DESCRIPTION
Room names may be numbers in practice. The name column in the Rooms sheet is already correctly set as "plain text". And so was the room column in the Meetings sheet. But the room column in the List/Breakouts sheet wasn't.

Fixes #290 