### PR TITLE
Rename admin issue section to "Do not edit below this line"

### DIFF
--- a/tools/common/session-sections.mjs
+++ b/tools/common/session-sections.mjs
@@ -7,17 +7,8 @@ export function getSessionSections(template) {
   // purpose of validation and serialization, we need to add them to the list
   // of sections (as custom "auto hide" sections that only get displayed when
   // they are not empty).
-  // Same thing for the "conflicts" section, although only for TPAC group
-  // meetings and we actually want to add the section even when it's empty.
-  if (!sessionSections.find(section => section.id === 'conflicts')) {
-    sessionSections.push({
-      id: 'conflicts',
-      attributes: {
-        label: 'Scheduling conflicts to avoid',
-        adminOnly: true
-      }
-    });
-  }
+  // Same thing for the "conflicts" section, although we actually want to add
+  // the section even when it's empty.
   if (!sessionSections.find(section => section.id === 'calendar')) {
     sessionSections.push({
       id: 'calendar',
@@ -33,6 +24,15 @@ export function getSessionSections(template) {
       attributes: {
         label: 'Meeting materials',
         autoHide: true
+      }
+    });
+  }
+  if (!sessionSections.find(section => section.id === 'conflicts')) {
+    sessionSections.push({
+      id: 'conflicts',
+      attributes: {
+        label: 'Do not edit below this line',
+        adminOnly: true
       }
     });
   }


### PR DESCRIPTION
The section "Scheduling conflicts to avoid (For meeting planners only)" is intended as a private section for meeting planners to create a machine-readable list of sessions to avoid conflicts with. It has been understood by sessions proposers as the place to report about conflicts in prose.

Note: we could "hide" the section and list of conflicts in a comment. But then the good thing about showing them is that we can then hop between conflicting issues.

Close #296.