### PR TITLE
Support same group meetings in parallel

### DIFF
--- a/test/check-allowed-in-parallel.mjs
+++ b/test/check-allowed-in-parallel.mjs
@@ -1,0 +1,1 @@
+check-allowed-in-parallel.mjs

--- a/test/check-allowed-in-parallel.mjs
+++ b/test/check-allowed-in-parallel.mjs
@@ -1,1 +1,0 @@
-check-allowed-in-parallel.mjs

--- a/test/check-project-validation.mjs
+++ b/test/check-project-validation.mjs
@@ -95,4 +95,21 @@ describe('Project validation', function () {
       'TPAC events should have at least 12 slots, 4 slots found'
     ]);
   });
+
+  it('validates allowed in parallel values', async function () {
+    setEnvKey('REPOSITORY', 'test/project-validation-allowed-in-parallel');
+    const project = await loadProject();
+    const errors = await validateProject(project);
+    assert.deepStrictEqual(errors, []);
+  });
+
+  it('reports about invalid allowed in parallel values', async function () {
+    setEnvKey('REPOSITORY', 'test/project-validation-allowed-in-parallel');
+    const project = await loadProject();
+    project.metadata.allowedInParallel = `foo,bar`;
+    const errors = await validateProject(project);
+    assert.deepStrictEqual(errors, [
+      'The "allowed in parallel" info must contain line-separated lists of a comma-separated list of session numbers.'
+    ]);
+  });
 })

--- a/test/data/project-validation-allowed-in-parallel.mjs
+++ b/test/data/project-validation-allowed-in-parallel.mjs
@@ -1,0 +1,10 @@
+export default {
+  metadata: {
+    meeting: 'Allowed in parallel validation',
+    timezone: 'Etc/UTC',
+    allowedInParallel: `
+      25,37,1
+      42,3
+    `
+  }
+}

--- a/tools/appscript/lib/project.mjs
+++ b/tools/appscript/lib/project.mjs
@@ -157,7 +157,8 @@ export function getProject(spreadsheet) {
       tracks: getSetting('Show tracks in calendar') === 'no' ? 'hide' : 'show',
       meeting: getSetting('Meeting name in calendar', ''),
       slug: getSetting('Meeting slug', ''),
-      reponame: getSetting('GitHub repository name')
+      reponame: getSetting('GitHub repository name'),
+      allowedInParallel: getSetting('Allowed in parallel', '')
     },
 
     rooms: sheets.rooms.values
@@ -663,6 +664,9 @@ export function refreshProject(spreadsheet, project, { what }) {
       }
       else if (name === 'reponame') {
         setSetting('GitHub repository name', value);
+      }
+      else if (name === 'allowedInParallel') {
+        setSetting('Allowed in parallel', value);
       }
       else {
         setSetting(name, value);

--- a/tools/common/project.mjs
+++ b/tools/common/project.mjs
@@ -251,6 +251,13 @@ export function validateProject(project) {
         !['no', 'draft', 'tentative', 'confirmed'].includes(project.metadata.calendar)) {
       errors.push('The "calendar" info must be one of "no", "draft", "tentative" or "confirmed"');
     }
+    if (project.metadata.allowedInParallel?.trim() &&
+        !project.metadata.allowedInParallel
+          .trim()
+          .split('\n')
+          .every(line => line.trim().match(/^\d+(,\d+)+$/))) {
+      errors.push('The "allowed in parallel" info must contain line-separated lists of a comma-separated list of session numbers.');
+    }
   }
 
   for (const slot of project.slots) {

--- a/tools/common/schedule.mjs
+++ b/tools/common/schedule.mjs
@@ -31,6 +31,7 @@ import { parseSessionMeetings,
          meetsInParallelWith,
          meetsInRoom,
          meetsAt } from './meetings.mjs';
+import { explicitlyAllowedInParallel } from './session.mjs';
 import { getProjectSlot } from './project.mjs';
 import { isSlotAcceptable } from './timeofday.mjs';
 
@@ -284,8 +285,10 @@ export function suggestSchedule(project, { seed }) {
 
       // There must be no session chaired by the same chair at that time
       // or there must be no session for the same group at that time
+      // (unless this parallelism is explicitly allowed)
       if (project.metadata.type === 'groups') {
         const groupConflict = potentialConflicts.find(s =>
+          !explicitlyAllowedInParallel(session, s, project) &&
           s.groups.find(c1 => session.groups.find(c2 =>
             c1.name && c1.name === c2.name)) &&
           (s.description.type !== 'plenary' || session.description.type !== 'plenary')

--- a/tools/common/session.mjs
+++ b/tools/common/session.mjs
@@ -682,3 +682,23 @@ export async function updateSessionDescription(session) {
     throw new Error(`GraphQL error, could not update issue body`);
   }
 }
+
+/**
+ * Returns true if the supposedly conflicting sessions are explicitly
+ * allowed to meet in parallel
+ */
+export function explicitlyAllowedInParallel(session1, session2, project) {
+  const allowedInParallel = (project.metadata.allowedInParallel ?? '')
+    .trim()
+    .split('\n')
+    .map(line => line
+      .trim()
+      .split(',')
+      .map(nb => nb.trim())
+      .map(nb => parseInt(nb, 10))
+    );
+  return allowedInParallel.find(list =>
+    list.includes(session1.number) &&
+    list.includes(session2.number)
+  )
+}

--- a/tools/common/validate.mjs
+++ b/tools/common/validate.mjs
@@ -1,7 +1,11 @@
 import { fetchSessionChairs, validateSessionChairs } from './chairs.mjs';
 import { fetchSessionGroups, validateSessionGroups } from './groups.mjs';
 import { validateProject } from './project.mjs';
-import { initSectionHandlers, validateSessionBody, parseSessionBody } from './session.mjs';
+import {
+  initSectionHandlers,
+  validateSessionBody,
+  parseSessionBody,
+  explicitlyAllowedInParallel } from './session.mjs';
 import { parseSessionMeetings, meetsAt, meetsInParallelWith } from './meetings.mjs';
 import { isSlotAcceptable } from './timeofday.mjs';
 import todoStrings from './todostrings.mjs';
@@ -616,7 +620,10 @@ ${projectErrors.map(error => '- ' + error).join('\n')}`);
   const chairConflictErrors = meetings
     .filter(meeting => meeting.day && meeting.slot)
     .map(meeting => project.sessions
-      .filter(s => s !== session && meetsInParallelWith(s, meeting, project))
+      .filter(s => s !== session &&
+        !explicitlyAllowedInParallel(session, s, project) &&
+        meetsInParallelWith(s, meeting, project)
+      )
       .map(s => {
         let inboth = [];
         try {


### PR DESCRIPTION
See #348. Some groups may want to split and allow their sub-groups to meet in parallel. The scheduler and the validator prevents that by default on the grounds that the same group cannot meet twice at the same time. An explicit list of meetings that may run in parallel can now be specified in the "Event" tab of the spreadsheet in an "Allow in parallel" setting that must contain a line-separated list of comma-separated meeting numbers.

For example, the value `"25,37"` means that meetings 25 and 37, supposedly for the same underlying group, may be scheduled in parallel and should not trigger any validation error.